### PR TITLE
Refactor to compile to ES modules

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,16 +1,18 @@
 {
     "root": true,
     "parser": "@typescript-eslint/parser",
-    "plugins": [
-        "@typescript-eslint"
-    ],
     "extends": [
         "eslint:recommended",
         "plugin:@typescript-eslint/eslint-recommended",
-        "plugin:@typescript-eslint/recommended"
+        "plugin:@typescript-eslint/recommended",
+        "plugin:unicorn/recommended"
+    ],
+    "plugins": [
+        "@typescript-eslint",
+        "unicorn"
     ],
     "parserOptions": {
-        "ecmaVersion": 2020,
+        "ecmaVersion": 2021,
         "sourceType": "module",
         "project": "./tsconfig.json"
     },
@@ -20,10 +22,15 @@
     },
     
     "rules": {
-        "strict": [
-            "error",
-            "global"
-        ],
+        // UNICORN
+        "unicorn/prevent-abbreviations": "off",
+        "unicorn/prefer-ternary": "off",
+        "unicorn/filename-case": "off",
+        "unicorn/no-array-reduce": "off",
+        "unicorn/no-process-exit": "off",
+        "unicorn/prefer-object-from-entries": "off",
+        "unicorn/no-null": "off",
+        // ESLINT
         "getter-return": "error",
         "no-compare-neg-zero": "error",
         "no-unsafe-negation": "error",
@@ -84,14 +91,7 @@
         ],
         "comma-dangle": [
             "error",
-            {
-                "arrays": "always-multiline",
-                "objects": "always-multiline",
-                "imports": "always-multiline",
-                "exports": "always-multiline",
-                // "functions": "never",
-                "functions": "always-multiline"
-            }
+            "always-multiline"
         ],
         "comma-spacing": "off",
         "@typescript-eslint/comma-spacing": "error",
@@ -273,88 +273,6 @@
             "method"
         ],
         "@typescript-eslint/naming-convention": "off",
-        // "@typescript-eslint/naming-convention": [
-        //     "error",
-        //     {
-        //         "selector": "default",
-        //         "format": ["snake_case"]
-        //     },
-        //     {
-        //         "selector": "variable",
-        //         "format": ["snake_case", "UPPER_CASE"],
-        //         "leadingUnderscore": "allow"
-        //     },
-        //     {
-        //         "selector": "variable",
-        //         "format": ["camelCase"],
-        //         "leadingUnderscore": "allow",
-        //         "filter": {
-        //             "match": true,
-        //             "regex": "\\w+Id"
-        //         }
-        //     },
-        //     {
-        //         "selector": "function",
-        //         "format": ["camelCase"]
-        //     },
-        //     {
-        //         "selector": "parameter",
-        //         "format": ["snake_case"],
-        //         "leadingUnderscore": "allow"
-        //     },
-        //     {
-        //         "selector": "parameter",
-        //         "format": ["camelCase"],
-        //         "filter": {
-        //             "match": true,
-        //             "regex": "\\w+Id"
-        //         }
-        //     },
-        //     {
-        //         "selector": "property",
-        //         "format": ["snake_case", "UPPER_CASE"],
-        //         "leadingUnderscore": "allow"
-        //     },
-        //     {
-        //         "selector": "property",
-        //         "format": ["camelCase"],
-        //         "filter": {
-        //             "match": true,
-        //             "regex": "\\w+Id"
-        //         }
-        //     },
-        //     {
-        //         "selector": "property",
-        //         "format": ["snake_case", "UPPER_CASE"],
-        //         "modifiers": ["private"],
-        //         "leadingUnderscore": "require"
-        //     },
-        //     {
-        //         "selector": "property",
-        //         "format": ["camelCase"],
-        //         "modifiers": ["private"],
-        //         "leadingUnderscore": "require",
-        //         "filter": {
-        //             "match": true,
-        //             "regex": "\\w+Id"
-        //         }
-        //     },
-        //     {
-        //         "selector": "method",
-        //         "format": ["camelCase"],
-        //         "leadingUnderscore": "allow"
-        //     },
-        //     {
-        //         "selector": "method",
-        //         "format": ["camelCase"],
-        //         "modifiers": ["private"],
-        //         "leadingUnderscore": "require"
-        //     },
-        //     {
-        //         "selector": "typeLike",
-        //         "format": ["PascalCase"]
-        //     }
-        // ],
         "@typescript-eslint/no-explicit-any": "off",
         "@typescript-eslint/no-extra-non-null-assertion": "error",
         "@typescript-eslint/no-floating-promises": "error",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.4.3",
       "license": "GPL-3.0",
       "dependencies": {
-        "@discordjs/builders": "^0.8.1",
+        "@discordjs/builders": "^0.7.0",
         "@discordjs/collection": "^0.3.1",
         "@discordjs/opus": "^0.6.0",
         "@discordjs/voice": "^0.6.0",
@@ -23,13 +23,13 @@
         "discord.js": "^13.3.1",
         "diskusage": "^1.1.3",
         "dotenv": "^10.0.0",
-        "escape-string-regexp": "^4.0.0",
+        "escape-string-regexp": "^5.0.0",
         "express": "^4.17.1",
         "fluent-ffmpeg": "^2.1.2",
         "fs-extra": "^10.0.0",
         "mongodb": "^4.1.2",
         "nanoid": "^3.1.23",
-        "node-fetch": "^2.6.2",
+        "node-fetch": "^3.0.0",
         "query-string": "^7.0.1",
         "sodium": "^3.0.2",
         "temp": "^0.9.4",
@@ -48,7 +48,6 @@
         "@types/fs-extra": "^9.0.12",
         "@types/mime": "^2.0.3",
         "@types/node": "^16.9.1",
-        "@types/node-fetch": "^2.5.12",
         "@types/temp": "^0.9.1",
         "@types/tmp": "^0.2.1",
         "@typescript-eslint/eslint-plugin": "^5.2.0",
@@ -199,18 +198,18 @@
       }
     },
     "node_modules/@discordjs/builders": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/@discordjs/builders/-/builders-0.8.1.tgz",
-      "integrity": "sha512-kYJMvZ/BjRD1/6G2t1pQop2yoJNUmYvvKeG4mOBUCHFmfb7WIeBFmN/eSiP3cVSfRx3lbNiyxkdd5JzhjQnGbg==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@discordjs/builders/-/builders-0.7.0.tgz",
+      "integrity": "sha512-0dnRH5ABy6DfyPU+gYeIE16P6+fnc9BSK53r0/jCe0aJiBQIVLcPrA7r/5vBV0MaoQOeuhlRQ2vwoawABDkn5w==",
       "dependencies": {
         "@sindresorhus/is": "^4.2.0",
         "discord-api-types": "^0.24.0",
-        "ow": "^0.28.1",
+        "ow": "^0.27.0",
         "ts-mixer": "^6.0.0",
         "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">=16.0.0",
+        "node": ">=14.0.0",
         "npm": ">=7.0.0"
       }
     },
@@ -261,6 +260,36 @@
       },
       "bin": {
         "node-pre-gyp": "bin/node-pre-gyp"
+      }
+    },
+    "node_modules/@discordjs/node-pre-gyp/node_modules/node-fetch": {
+      "version": "2.6.6",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.6.tgz",
+      "integrity": "sha512-Z8/6vRlTUChSdIgMa51jxQ4lrw/Jy5SOW10ObaA47/RElsAN2c5Pn8bTgFGWn/ibwzXTE8qwr1Yzx28vsecXEA==",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      }
+    },
+    "node_modules/@discordjs/node-pre-gyp/node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
+    },
+    "node_modules/@discordjs/node-pre-gyp/node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
+    },
+    "node_modules/@discordjs/node-pre-gyp/node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/@discordjs/opus": {
@@ -442,6 +471,36 @@
         "node-pre-gyp": "bin/node-pre-gyp"
       }
     },
+    "node_modules/@mapbox/node-pre-gyp/node_modules/node-fetch": {
+      "version": "2.6.6",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.6.tgz",
+      "integrity": "sha512-Z8/6vRlTUChSdIgMa51jxQ4lrw/Jy5SOW10ObaA47/RElsAN2c5Pn8bTgFGWn/ibwzXTE8qwr1Yzx28vsecXEA==",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      }
+    },
+    "node_modules/@mapbox/node-pre-gyp/node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
+    },
+    "node_modules/@mapbox/node-pre-gyp/node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
+    },
+    "node_modules/@mapbox/node-pre-gyp/node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -504,6 +563,36 @@
       "dependencies": {
         "node-fetch": "^2.6.1",
         "raw-body": "^2.4.1"
+      }
+    },
+    "node_modules/@top-gg/sdk/node_modules/node-fetch": {
+      "version": "2.6.6",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.6.tgz",
+      "integrity": "sha512-Z8/6vRlTUChSdIgMa51jxQ4lrw/Jy5SOW10ObaA47/RElsAN2c5Pn8bTgFGWn/ibwzXTE8qwr1Yzx28vsecXEA==",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      }
+    },
+    "node_modules/@top-gg/sdk/node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
+    },
+    "node_modules/@top-gg/sdk/node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
+    },
+    "node_modules/@top-gg/sdk/node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/@tsconfig/node10": {
@@ -1800,6 +1889,14 @@
         "node": ">=8"
       }
     },
+    "node_modules/data-uri-to-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-3.0.1.tgz",
+      "integrity": "sha512-WboRycPNsVw3B3TL559F7kuBUM4d8CgMEvk6xEJlOp7OBPjt6G7z8WMWlD2rOFZLk6OYfFIUGsCOWzcQH9K2og==",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/dateformat": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-3.0.3.tgz",
@@ -1993,6 +2090,22 @@
         "npm": ">=7.0.0"
       }
     },
+    "node_modules/discord.js/node_modules/@discordjs/builders": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/@discordjs/builders/-/builders-0.8.2.tgz",
+      "integrity": "sha512-/YRd11SrcluqXkKppq/FAVzLIPRVlIVmc6X8ZklspzMIHDtJ+A4W37D43SHvLdH//+NnK+SHW/WeOF4Ts54PeQ==",
+      "dependencies": {
+        "@sindresorhus/is": "^4.2.0",
+        "discord-api-types": "^0.24.0",
+        "ow": "^0.27.0",
+        "ts-mixer": "^6.0.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
     "node_modules/discord.js/node_modules/@types/ws": {
       "version": "8.2.0",
       "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.2.0.tgz",
@@ -2007,6 +2120,36 @@
       "integrity": "sha512-X0uA2a92cRjowUEXpLZIHWl4jiX1NsUpDhcEOpa1/hpO1vkaokgZ8kkPtPih9hHth5UVQ3mHBu/PpB4qjyfJ4A==",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/discord.js/node_modules/node-fetch": {
+      "version": "2.6.6",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.6.tgz",
+      "integrity": "sha512-Z8/6vRlTUChSdIgMa51jxQ4lrw/Jy5SOW10ObaA47/RElsAN2c5Pn8bTgFGWn/ibwzXTE8qwr1Yzx28vsecXEA==",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      }
+    },
+    "node_modules/discord.js/node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
+    },
+    "node_modules/discord.js/node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
+    },
+    "node_modules/discord.js/node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/discord.js/node_modules/ws": {
@@ -2218,11 +2361,11 @@
       "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg="
     },
     "node_modules/escape-string-regexp": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
-      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
       "engines": {
-        "node": ">=10"
+        "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -2330,6 +2473,18 @@
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/eslint/node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/eslint/node_modules/eslint-scope": {
@@ -2570,6 +2725,27 @@
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/fecha/-/fecha-4.2.1.tgz",
       "integrity": "sha512-MMMQ0ludy/nBs1/o0zVOiKTpG7qMbonKUzjJgQFEuvq6INZ1OraKPRAWkBq5vlKLOUMpmNYG1JoN3oDPUQ9m3Q=="
+    },
+    "node_modules/fetch-blob": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.1.3.tgz",
+      "integrity": "sha512-ax1Y5I9w+9+JiM+wdHkhBoxew+zG4AJ2SvAD1v1szpddUIiPERVGBxrMcB2ZqW0Y3PP8bOWYv2zqQq1Jp2kqUQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "dependencies": {
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
+      }
     },
     "node_modules/figures": {
       "version": "3.2.0",
@@ -4047,33 +4223,19 @@
       "integrity": "sha512-eazsqzwG2lskuzBqCGPi7Ac2UgOoMz8JVOXVhTvvPDYhthvNpefx8jWD8Np7Gv+2Sz0FlPWZk0nJV0z598Wn8Q=="
     },
     "node_modules/node-fetch": {
-      "version": "2.6.5",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.5.tgz",
-      "integrity": "sha512-mmlIVHJEu5rnIxgEgez6b9GgWXbkZj5YZ7fx+2r94a2E+Uirsp6HsPTPlomfdHtpt/B0cdKviwkoaM6pyvUOpQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.0.0.tgz",
+      "integrity": "sha512-bKMI+C7/T/SPU1lKnbQbwxptpCrG9ashG+VkytmXCPZyuM9jB6VU+hY0oi4lC8LxTtAeWdckNCTa3nrGsAdA3Q==",
       "dependencies": {
-        "whatwg-url": "^5.0.0"
+        "data-uri-to-buffer": "^3.0.1",
+        "fetch-blob": "^3.1.2"
       },
       "engines": {
-        "node": "4.x || >=6.0.0"
-      }
-    },
-    "node_modules/node-fetch/node_modules/tr46": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
-    },
-    "node_modules/node-fetch/node_modules/webidl-conversions": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
-    },
-    "node_modules/node-fetch/node_modules/whatwg-url": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
-      "dependencies": {
-        "tr46": "~0.0.3",
-        "webidl-conversions": "^3.0.0"
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
       }
     },
     "node_modules/node-gyp-build": {
@@ -4196,19 +4358,30 @@
       }
     },
     "node_modules/ow": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/ow/-/ow-0.28.1.tgz",
-      "integrity": "sha512-1EZTywPZeUKac9gD7q8np3Aj+V54kvfIcjNEVNDSbG2Ys5xA5foW2HquvMMqgyWGLqIFMlc0Iq/HmyMHqN48sA==",
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/ow/-/ow-0.27.0.tgz",
+      "integrity": "sha512-SGnrGUbhn4VaUGdU0EJLMwZWSupPmF46hnTRII7aCLCrqixTAC5eKo8kI4/XXf1eaaI8YEVT+3FeGNJI9himAQ==",
       "dependencies": {
-        "@sindresorhus/is": "^4.2.0",
+        "@sindresorhus/is": "^4.0.1",
         "callsites": "^3.1.0",
         "dot-prop": "^6.0.1",
         "lodash.isequal": "^4.5.0",
-        "type-fest": "^2.3.4",
+        "type-fest": "^1.2.1",
         "vali-date": "^1.0.0"
       },
       "engines": {
         "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ow/node_modules/type-fest": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.4.0.tgz",
+      "integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==",
+      "engines": {
+        "node": ">=10"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -5509,6 +5682,7 @@
       "version": "2.5.2",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.5.2.tgz",
       "integrity": "sha512-WMbytmAs5PUTqwGJRE+WoRrD2S0bYFtHX8k4Y/1l18CG5kqA3keJud9pPQ/r30FE9n8XRFCXF9BbccHIZzRYJw==",
+      "dev": true,
       "engines": {
         "node": ">=12.20"
       },
@@ -5639,6 +5813,14 @@
       "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/web-streams-polyfill": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.1.1.tgz",
+      "integrity": "sha512-Czi3fG883e96T4DLEPRvufrF2ydhOOW1+1a6c3gNjH2aIh50DNFBdfwh2AKoOf1rXvpvavAoA11Qdq9+BKjE0Q==",
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/webidl-conversions": {
@@ -6049,13 +6231,13 @@
       }
     },
     "@discordjs/builders": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/@discordjs/builders/-/builders-0.8.1.tgz",
-      "integrity": "sha512-kYJMvZ/BjRD1/6G2t1pQop2yoJNUmYvvKeG4mOBUCHFmfb7WIeBFmN/eSiP3cVSfRx3lbNiyxkdd5JzhjQnGbg==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@discordjs/builders/-/builders-0.7.0.tgz",
+      "integrity": "sha512-0dnRH5ABy6DfyPU+gYeIE16P6+fnc9BSK53r0/jCe0aJiBQIVLcPrA7r/5vBV0MaoQOeuhlRQ2vwoawABDkn5w==",
       "requires": {
         "@sindresorhus/is": "^4.2.0",
         "discord-api-types": "^0.24.0",
-        "ow": "^0.28.1",
+        "ow": "^0.27.0",
         "ts-mixer": "^6.0.0",
         "tslib": "^2.3.1"
       },
@@ -6096,6 +6278,35 @@
         "rimraf": "^3.0.2",
         "semver": "^7.3.5",
         "tar": "^6.1.8"
+      },
+      "dependencies": {
+        "node-fetch": {
+          "version": "2.6.6",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.6.tgz",
+          "integrity": "sha512-Z8/6vRlTUChSdIgMa51jxQ4lrw/Jy5SOW10ObaA47/RElsAN2c5Pn8bTgFGWn/ibwzXTE8qwr1Yzx28vsecXEA==",
+          "requires": {
+            "whatwg-url": "^5.0.0"
+          }
+        },
+        "tr46": {
+          "version": "0.0.3",
+          "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+          "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
+        },
+        "webidl-conversions": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+          "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
+        },
+        "whatwg-url": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+          "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
+          "requires": {
+            "tr46": "~0.0.3",
+            "webidl-conversions": "^3.0.0"
+          }
+        }
       }
     },
     "@discordjs/opus": {
@@ -6231,6 +6442,35 @@
         "rimraf": "^3.0.2",
         "semver": "^7.3.5",
         "tar": "^6.1.11"
+      },
+      "dependencies": {
+        "node-fetch": {
+          "version": "2.6.6",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.6.tgz",
+          "integrity": "sha512-Z8/6vRlTUChSdIgMa51jxQ4lrw/Jy5SOW10ObaA47/RElsAN2c5Pn8bTgFGWn/ibwzXTE8qwr1Yzx28vsecXEA==",
+          "requires": {
+            "whatwg-url": "^5.0.0"
+          }
+        },
+        "tr46": {
+          "version": "0.0.3",
+          "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+          "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
+        },
+        "webidl-conversions": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+          "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
+        },
+        "whatwg-url": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+          "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
+          "requires": {
+            "tr46": "~0.0.3",
+            "webidl-conversions": "^3.0.0"
+          }
+        }
       }
     },
     "@nodelib/fs.scandir": {
@@ -6276,6 +6516,35 @@
       "requires": {
         "node-fetch": "^2.6.1",
         "raw-body": "^2.4.1"
+      },
+      "dependencies": {
+        "node-fetch": {
+          "version": "2.6.6",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.6.tgz",
+          "integrity": "sha512-Z8/6vRlTUChSdIgMa51jxQ4lrw/Jy5SOW10ObaA47/RElsAN2c5Pn8bTgFGWn/ibwzXTE8qwr1Yzx28vsecXEA==",
+          "requires": {
+            "whatwg-url": "^5.0.0"
+          }
+        },
+        "tr46": {
+          "version": "0.0.3",
+          "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+          "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
+        },
+        "webidl-conversions": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+          "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
+        },
+        "whatwg-url": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+          "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
+          "requires": {
+            "tr46": "~0.0.3",
+            "webidl-conversions": "^3.0.0"
+          }
+        }
       }
     },
     "@tsconfig/node10": {
@@ -7297,6 +7566,11 @@
       "integrity": "sha512-2iy1EkLdlBzQGvbweYRFxmFath8+K7+AKB0TlhHWkNuH+TmovaMH/Wp7V7R4u7f4SnX3OgLsU9t1NI9ioDnUpg==",
       "dev": true
     },
+    "data-uri-to-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-3.0.1.tgz",
+      "integrity": "sha512-WboRycPNsVw3B3TL559F7kuBUM4d8CgMEvk6xEJlOp7OBPjt6G7z8WMWlD2rOFZLk6OYfFIUGsCOWzcQH9K2og=="
+    },
     "dateformat": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-3.0.3.tgz",
@@ -7432,6 +7706,18 @@
         "ws": "^8.2.3"
       },
       "dependencies": {
+        "@discordjs/builders": {
+          "version": "0.8.2",
+          "resolved": "https://registry.npmjs.org/@discordjs/builders/-/builders-0.8.2.tgz",
+          "integrity": "sha512-/YRd11SrcluqXkKppq/FAVzLIPRVlIVmc6X8ZklspzMIHDtJ+A4W37D43SHvLdH//+NnK+SHW/WeOF4Ts54PeQ==",
+          "requires": {
+            "@sindresorhus/is": "^4.2.0",
+            "discord-api-types": "^0.24.0",
+            "ow": "^0.27.0",
+            "ts-mixer": "^6.0.0",
+            "tslib": "^2.3.1"
+          }
+        },
         "@types/ws": {
           "version": "8.2.0",
           "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.2.0.tgz",
@@ -7444,6 +7730,33 @@
           "version": "0.24.0",
           "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.24.0.tgz",
           "integrity": "sha512-X0uA2a92cRjowUEXpLZIHWl4jiX1NsUpDhcEOpa1/hpO1vkaokgZ8kkPtPih9hHth5UVQ3mHBu/PpB4qjyfJ4A=="
+        },
+        "node-fetch": {
+          "version": "2.6.6",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.6.tgz",
+          "integrity": "sha512-Z8/6vRlTUChSdIgMa51jxQ4lrw/Jy5SOW10ObaA47/RElsAN2c5Pn8bTgFGWn/ibwzXTE8qwr1Yzx28vsecXEA==",
+          "requires": {
+            "whatwg-url": "^5.0.0"
+          }
+        },
+        "tr46": {
+          "version": "0.0.3",
+          "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+          "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
+        },
+        "webidl-conversions": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+          "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
+        },
+        "whatwg-url": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+          "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
+          "requires": {
+            "tr46": "~0.0.3",
+            "webidl-conversions": "^3.0.0"
+          }
         },
         "ws": {
           "version": "8.2.3",
@@ -7603,9 +7916,9 @@
       "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg="
     },
     "escape-string-regexp": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
-      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw=="
     },
     "eslint": {
       "version": "8.1.0",
@@ -7653,6 +7966,12 @@
         "v8-compile-cache": "^2.0.3"
       },
       "dependencies": {
+        "escape-string-regexp": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+          "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+          "dev": true
+        },
         "eslint-scope": {
           "version": "6.0.0",
           "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-6.0.0.tgz",
@@ -7885,6 +8204,14 @@
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/fecha/-/fecha-4.2.1.tgz",
       "integrity": "sha512-MMMQ0ludy/nBs1/o0zVOiKTpG7qMbonKUzjJgQFEuvq6INZ1OraKPRAWkBq5vlKLOUMpmNYG1JoN3oDPUQ9m3Q=="
+    },
+    "fetch-blob": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.1.3.tgz",
+      "integrity": "sha512-ax1Y5I9w+9+JiM+wdHkhBoxew+zG4AJ2SvAD1v1szpddUIiPERVGBxrMcB2ZqW0Y3PP8bOWYv2zqQq1Jp2kqUQ==",
+      "requires": {
+        "web-streams-polyfill": "^3.0.3"
+      }
     },
     "figures": {
       "version": "3.2.0",
@@ -9003,32 +9330,12 @@
       "integrity": "sha512-eazsqzwG2lskuzBqCGPi7Ac2UgOoMz8JVOXVhTvvPDYhthvNpefx8jWD8Np7Gv+2Sz0FlPWZk0nJV0z598Wn8Q=="
     },
     "node-fetch": {
-      "version": "2.6.5",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.5.tgz",
-      "integrity": "sha512-mmlIVHJEu5rnIxgEgez6b9GgWXbkZj5YZ7fx+2r94a2E+Uirsp6HsPTPlomfdHtpt/B0cdKviwkoaM6pyvUOpQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.0.0.tgz",
+      "integrity": "sha512-bKMI+C7/T/SPU1lKnbQbwxptpCrG9ashG+VkytmXCPZyuM9jB6VU+hY0oi4lC8LxTtAeWdckNCTa3nrGsAdA3Q==",
       "requires": {
-        "whatwg-url": "^5.0.0"
-      },
-      "dependencies": {
-        "tr46": {
-          "version": "0.0.3",
-          "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-          "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
-        },
-        "webidl-conversions": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-          "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
-        },
-        "whatwg-url": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-          "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
-          "requires": {
-            "tr46": "~0.0.3",
-            "webidl-conversions": "^3.0.0"
-          }
-        }
+        "data-uri-to-buffer": "^3.0.1",
+        "fetch-blob": "^3.1.2"
       }
     },
     "node-gyp-build": {
@@ -9122,16 +9429,23 @@
       }
     },
     "ow": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/ow/-/ow-0.28.1.tgz",
-      "integrity": "sha512-1EZTywPZeUKac9gD7q8np3Aj+V54kvfIcjNEVNDSbG2Ys5xA5foW2HquvMMqgyWGLqIFMlc0Iq/HmyMHqN48sA==",
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/ow/-/ow-0.27.0.tgz",
+      "integrity": "sha512-SGnrGUbhn4VaUGdU0EJLMwZWSupPmF46hnTRII7aCLCrqixTAC5eKo8kI4/XXf1eaaI8YEVT+3FeGNJI9himAQ==",
       "requires": {
-        "@sindresorhus/is": "^4.2.0",
+        "@sindresorhus/is": "^4.0.1",
         "callsites": "^3.1.0",
         "dot-prop": "^6.0.1",
         "lodash.isequal": "^4.5.0",
-        "type-fest": "^2.3.4",
+        "type-fest": "^1.2.1",
         "vali-date": "^1.0.0"
+      },
+      "dependencies": {
+        "type-fest": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.4.0.tgz",
+          "integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA=="
+        }
       }
     },
     "p-limit": {
@@ -10098,7 +10412,8 @@
     "type-fest": {
       "version": "2.5.2",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.5.2.tgz",
-      "integrity": "sha512-WMbytmAs5PUTqwGJRE+WoRrD2S0bYFtHX8k4Y/1l18CG5kqA3keJud9pPQ/r30FE9n8XRFCXF9BbccHIZzRYJw=="
+      "integrity": "sha512-WMbytmAs5PUTqwGJRE+WoRrD2S0bYFtHX8k4Y/1l18CG5kqA3keJud9pPQ/r30FE9n8XRFCXF9BbccHIZzRYJw==",
+      "dev": true
     },
     "type-is": {
       "version": "1.6.18",
@@ -10189,6 +10504,11 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
       "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw="
+    },
+    "web-streams-polyfill": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.1.1.tgz",
+      "integrity": "sha512-Czi3fG883e96T4DLEPRvufrF2ydhOOW1+1a6c3gNjH2aIh50DNFBdfwh2AKoOf1rXvpvavAoA11Qdq9+BKjE0Q=="
     },
     "webidl-conversions": {
       "version": "6.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.4.3",
       "license": "GPL-3.0",
       "dependencies": {
-        "@discordjs/builders": "^0.7.0",
+        "@discordjs/builders": "=0.7.0",
         "@discordjs/collection": "^0.3.1",
         "@discordjs/opus": "^0.6.0",
         "@discordjs/voice": "^0.6.0",
@@ -53,6 +53,7 @@
         "@typescript-eslint/eslint-plugin": "^5.2.0",
         "@typescript-eslint/parser": "^5.2.0",
         "eslint": "^8.1.0",
+        "eslint-plugin-unicorn": "^37.0.1",
         "rimraf": "^3.0.2",
         "standard-version": "^9.3.1",
         "ts-node": "^10.1.0",
@@ -64,12 +65,290 @@
       }
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.12.11",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.11.tgz",
-      "integrity": "sha512-Zt1yodBx1UcyiePMSkWnU4hPqhwq7hGi2nFL1LeA3EUl+q2LQx16MISgJ0+z7dnmgvP9QtIleuETGOiOH1RcIw==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.16.0.tgz",
+      "integrity": "sha512-IF4EOMEV+bfYwOmNxGzSnjR2EmQod7f1UXOpZM3l4i4o4QNwzjtJAu/HxdjHq0aYBvdqMuQEY1eg0nqW9ZPORA==",
       "dev": true,
       "dependencies": {
-        "@babel/highlight": "^7.10.4"
+        "@babel/highlight": "^7.16.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/compat-data": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.16.0.tgz",
+      "integrity": "sha512-DGjt2QZse5SGd9nfOSqO4WLJ8NN/oHkijbXbPrxuoJO3oIPJL3TciZs9FX+cOHNiY9E9l0opL8g7BmLe3T+9ew==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.16.0.tgz",
+      "integrity": "sha512-mYZEvshBRHGsIAiyH5PzCFTCfbWfoYbO/jcSdXQSUQu1/pW0xDZAUP7KEc32heqWTAfAHhV9j1vH8Sav7l+JNQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.16.0",
+        "@babel/generator": "^7.16.0",
+        "@babel/helper-compilation-targets": "^7.16.0",
+        "@babel/helper-module-transforms": "^7.16.0",
+        "@babel/helpers": "^7.16.0",
+        "@babel/parser": "^7.16.0",
+        "@babel/template": "^7.16.0",
+        "@babel/traverse": "^7.16.0",
+        "@babel/types": "^7.16.0",
+        "convert-source-map": "^1.7.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.1.2",
+        "semver": "^6.3.0",
+        "source-map": "^0.5.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/core/node_modules/semver": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/@babel/core/node_modules/source-map": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/@babel/eslint-parser": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/eslint-parser/-/eslint-parser-7.16.0.tgz",
+      "integrity": "sha512-c+AsYOHjI+FgCa+ifLd8sDXp4U4mjkfFgL9NdQWhuA731kAUJs0WdJIXET4A14EJAR9Jv9FFF/MzPWJfV9Oirw==",
+      "dev": true,
+      "dependencies": {
+        "eslint-scope": "^5.1.1",
+        "eslint-visitor-keys": "^2.1.0",
+        "semver": "^6.3.0"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || >=14.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": ">=7.11.0",
+        "eslint": "^7.5.0 || ^8.0.0"
+      }
+    },
+    "node_modules/@babel/eslint-parser/node_modules/eslint-visitor-keys": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
+      "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@babel/eslint-parser/node_modules/semver": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.16.0.tgz",
+      "integrity": "sha512-RR8hUCfRQn9j9RPKEVXo9LiwoxLPYn6hNZlvUOR8tSnaxlD0p0+la00ZP9/SnRt6HchKr+X0fO2r8vrETiJGew==",
+      "dev": true,
+      "dependencies": {
+        "@babel/types": "^7.16.0",
+        "jsesc": "^2.5.1",
+        "source-map": "^0.5.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/generator/node_modules/source-map": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.16.0.tgz",
+      "integrity": "sha512-S7iaOT1SYlqK0sQaCi21RX4+13hmdmnxIEAnQUB/eh7GeAnRjOUgTYpLkUOiRXzD+yog1JxP0qyAQZ7ZxVxLVg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/compat-data": "^7.16.0",
+        "@babel/helper-validator-option": "^7.14.5",
+        "browserslist": "^4.16.6",
+        "semver": "^6.3.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets/node_modules/semver": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/@babel/helper-function-name": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.16.0.tgz",
+      "integrity": "sha512-BZh4mEk1xi2h4HFjWUXRQX5AEx4rvaZxHgax9gcjdLWdkjsY7MKt5p0otjsg5noXw+pB+clMCjw+aEVYADMjog==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-get-function-arity": "^7.16.0",
+        "@babel/template": "^7.16.0",
+        "@babel/types": "^7.16.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-get-function-arity": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.16.0.tgz",
+      "integrity": "sha512-ASCquNcywC1NkYh/z7Cgp3w31YW8aojjYIlNg4VeJiHkqyP4AzIvr4qx7pYDb4/s8YcsZWqqOSxgkvjUz1kpDQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/types": "^7.16.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-hoist-variables": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.16.0.tgz",
+      "integrity": "sha512-1AZlpazjUR0EQZQv3sgRNfM9mEVWPK3M6vlalczA+EECcPz3XPh6VplbErL5UoMpChhSck5wAJHthlj1bYpcmg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/types": "^7.16.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-member-expression-to-functions": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.16.0.tgz",
+      "integrity": "sha512-bsjlBFPuWT6IWhl28EdrQ+gTvSvj5tqVP5Xeftp07SEuz5pLnsXZuDkDD3Rfcxy0IsHmbZ+7B2/9SHzxO0T+sQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/types": "^7.16.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.16.0.tgz",
+      "integrity": "sha512-kkH7sWzKPq0xt3H1n+ghb4xEMP8k0U7XV3kkB+ZGy69kDk2ySFW1qPi06sjKzFY3t1j6XbJSqr4mF9L7CYVyhg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/types": "^7.16.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.16.0.tgz",
+      "integrity": "sha512-My4cr9ATcaBbmaEa8M0dZNA74cfI6gitvUAskgDtAFmAqyFKDSHQo5YstxPbN+lzHl2D9l/YOEFqb2mtUh4gfA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.16.0",
+        "@babel/helper-replace-supers": "^7.16.0",
+        "@babel/helper-simple-access": "^7.16.0",
+        "@babel/helper-split-export-declaration": "^7.16.0",
+        "@babel/helper-validator-identifier": "^7.15.7",
+        "@babel/template": "^7.16.0",
+        "@babel/traverse": "^7.16.0",
+        "@babel/types": "^7.16.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-optimise-call-expression": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.16.0.tgz",
+      "integrity": "sha512-SuI467Gi2V8fkofm2JPnZzB/SUuXoJA5zXe/xzyPP2M04686RzFKFHPK6HDVN6JvWBIEW8tt9hPR7fXdn2Lgpw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/types": "^7.16.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-replace-supers": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.16.0.tgz",
+      "integrity": "sha512-TQxuQfSCdoha7cpRNJvfaYxxxzmbxXw/+6cS7V02eeDYyhxderSoMVALvwupA54/pZcOTtVeJ0xccp1nGWladA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-member-expression-to-functions": "^7.16.0",
+        "@babel/helper-optimise-call-expression": "^7.16.0",
+        "@babel/traverse": "^7.16.0",
+        "@babel/types": "^7.16.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-simple-access": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.16.0.tgz",
+      "integrity": "sha512-o1rjBT/gppAqKsYfUdfHq5Rk03lMQrkPHG1OWzHWpLgVXRH4HnMM9Et9CVdIqwkCQlobnGHEJMsgWP/jE1zUiw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/types": "^7.16.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-split-export-declaration": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.16.0.tgz",
+      "integrity": "sha512-0YMMRpuDFNGTHNRiiqJX19GjNXA4H0E8jZ2ibccfSxaCogbm3am5WN/2nQNj0YnQwGWM1J06GOcQ2qnh3+0paw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/types": "^7.16.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
@@ -81,13 +360,36 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@babel/highlight": {
+    "node_modules/@babel/helper-validator-option": {
       "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.14.5.tgz",
-      "integrity": "sha512-qf9u2WFWVV0MppaL877j2dBtQIDgmidgjGk5VIMw3OadXvYaXn66U1BFlH2t4+t3i+8PhedppRv+i40ABzd+gg==",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.14.5.tgz",
+      "integrity": "sha512-OX8D5eeX4XwcroVW45NMvoYaIuFI+GQpA2a8Gi+X/U/cDUIRsV37qQfF905F0htTRCREQIB4KqPeaveRJUl3Ow==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.16.0.tgz",
+      "integrity": "sha512-dVRM0StFMdKlkt7cVcGgwD8UMaBfWJHl3A83Yfs8GQ3MO0LHIIIMvK7Fa0RGOGUQ10qikLaX6D7o5htcQWgTMQ==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.14.5",
+        "@babel/template": "^7.16.0",
+        "@babel/traverse": "^7.16.0",
+        "@babel/types": "^7.16.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/highlight": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.16.0.tgz",
+      "integrity": "sha512-t8MH41kUQylBtu2+4IQA3atqevA2lRgqA2wyVB/YiWmsDSuylZZuXOUy9ric30hfzauEFfdsuk/eXTRrGrfd0g==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.15.7",
         "chalk": "^2.0.0",
         "js-tokens": "^4.0.0"
       },
@@ -164,6 +466,74 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.16.2",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.16.2.tgz",
+      "integrity": "sha512-RUVpT0G2h6rOZwqLDTrKk7ksNv7YpAilTnYe1/Q+eDjxEceRMKVWbCsX7t8h6C1qCFi/1Y8WZjcEPBAFG27GPw==",
+      "dev": true,
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.16.0.tgz",
+      "integrity": "sha512-MnZdpFD/ZdYhXwiunMqqgyZyucaYsbL0IrjoGjaVhGilz+x8YB++kRfygSOIj1yOtWKPlx7NBp+9I1RQSgsd5A==",
+      "dev": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.16.0",
+        "@babel/parser": "^7.16.0",
+        "@babel/types": "^7.16.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.16.0.tgz",
+      "integrity": "sha512-qQ84jIs1aRQxaGaxSysII9TuDaguZ5yVrEuC0BN2vcPlalwfLovVmCjbFDPECPXcYM/wLvNFfp8uDOliLxIoUQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.16.0",
+        "@babel/generator": "^7.16.0",
+        "@babel/helper-function-name": "^7.16.0",
+        "@babel/helper-hoist-variables": "^7.16.0",
+        "@babel/helper-split-export-declaration": "^7.16.0",
+        "@babel/parser": "^7.16.0",
+        "@babel/types": "^7.16.0",
+        "debug": "^4.1.0",
+        "globals": "^11.1.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse/node_modules/globals": {
+      "version": "11.12.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+      "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.16.0.tgz",
+      "integrity": "sha512-PJgg/k3SdLsGb3hhisFvtLOw5ts113klrpLuIPtCJIU+BB24fqq6lf8RWqKJEjzqXR9AEH1rIb5XTqwBHB+kQg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.15.7",
+        "to-fast-properties": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@cspotcode/source-map-consumer": {
@@ -1245,6 +1615,29 @@
         "node": ">=8"
       }
     },
+    "node_modules/browserslist": {
+      "version": "4.17.6",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.17.6.tgz",
+      "integrity": "sha512-uPgz3vyRTlEiCv4ee9KlsKgo2V6qPk7Jsn0KAn2OBqbqKo3iNcPEC1Ti6J4dwnz+aIRfEEEuOzC9IBk8tXUomw==",
+      "dev": true,
+      "dependencies": {
+        "caniuse-lite": "^1.0.30001274",
+        "electron-to-chromium": "^1.3.886",
+        "escalade": "^3.1.1",
+        "node-releases": "^2.0.1",
+        "picocolors": "^1.0.0"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/browserslist"
+      }
+    },
     "node_modules/bson": {
       "version": "4.5.3",
       "resolved": "https://registry.npmjs.org/bson/-/bson-4.5.3.tgz",
@@ -1297,6 +1690,18 @@
         "node": ">=6.14.2"
       }
     },
+    "node_modules/builtin-modules": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-3.2.0.tgz",
+      "integrity": "sha512-lGzLKcioL90C7wMczpkY0n/oART3MbBa8R9OFGE1rJxoVI86u4WAGfEk8Wjv10eKSyTHVGkSo3bvBylCEtk7LA==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/bytes": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.0.tgz",
@@ -1339,6 +1744,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001275",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001275.tgz",
+      "integrity": "sha512-ihJVvj8RX0kn9GgP43HKhb5q9s2XQn4nEQhdldEJvZhCsuiB2XOq6fAMYQZaN6FPWfsr2qU0cdL0CSbETwbJAg==",
+      "dev": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/browserslist"
+      }
+    },
     "node_modules/canvas": {
       "version": "2.8.0",
       "resolved": "https://registry.npmjs.org/canvas/-/canvas-2.8.0.tgz",
@@ -1374,6 +1789,33 @@
       "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/ci-info": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.2.0.tgz",
+      "integrity": "sha512-dVqRX7fLUm8J6FgHJ418XuIgDLZDkYcDFTeL6TA2gt5WlIZUQrrH6EZrNClwT/H0FateUsZkGIOPRrLbP+PR9A==",
+      "dev": true
+    },
+    "node_modules/clean-regexp": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/clean-regexp/-/clean-regexp-1.0.0.tgz",
+      "integrity": "sha1-jffHquUf02h06PjQW5GAvBGj/tc=",
+      "dev": true,
+      "dependencies": {
+        "escape-string-regexp": "^1.0.5"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/clean-regexp/node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8.0"
       }
     },
     "node_modules/cliui": {
@@ -1832,6 +2274,15 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/convert-source-map": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.8.0.tgz",
+      "integrity": "sha512-+OQdjP49zViI/6i7nIJpA8rAl4sV/JdPfU9nZs3VqOwGIgizICvuN2ru6fMd+4llL0tar18UYJXfZ/TWtmhUjA==",
+      "dev": true,
+      "dependencies": {
+        "safe-buffer": "~5.1.1"
       }
     },
     "node_modules/cookie": {
@@ -2295,6 +2746,12 @@
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
     },
+    "node_modules/electron-to-chromium": {
+      "version": "1.3.887",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.887.tgz",
+      "integrity": "sha512-QQUumrEjFDKSVYVdaeBmFdyQGoaV+fCSMyWHvfx/u22bRHSTeBQYt6P4jMY+gFd4kgKB9nqk7RMtWkDB49OYPA==",
+      "dev": true
+    },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
@@ -2426,6 +2883,185 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/eslint-plugin-unicorn": {
+      "version": "37.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-unicorn/-/eslint-plugin-unicorn-37.0.1.tgz",
+      "integrity": "sha512-E1jq5u9ojnadisJcPi+hMXTGSiIzkIUMDvWsBudsCGXvKUB2aNSU2TcfyW2/jAS5A4ryBXfzxLykMxX1EdluSQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.14.9",
+        "ci-info": "^3.2.0",
+        "clean-regexp": "^1.0.0",
+        "eslint-template-visitor": "^2.3.2",
+        "eslint-utils": "^3.0.0",
+        "esquery": "^1.4.0",
+        "indent-string": "4",
+        "is-builtin-module": "^3.1.0",
+        "lodash": "^4.17.21",
+        "pluralize": "^8.0.0",
+        "read-pkg-up": "^7.0.1",
+        "regexp-tree": "^0.1.23",
+        "safe-regex": "^2.1.1",
+        "semver": "^7.3.5",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/eslint-plugin-unicorn?sponsor=1"
+      },
+      "peerDependencies": {
+        "eslint": ">=7.32.0"
+      }
+    },
+    "node_modules/eslint-plugin-unicorn/node_modules/find-up": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "dev": true,
+      "dependencies": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/eslint-plugin-unicorn/node_modules/hosted-git-info": {
+      "version": "2.8.9",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
+      "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
+      "dev": true
+    },
+    "node_modules/eslint-plugin-unicorn/node_modules/locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "dev": true,
+      "dependencies": {
+        "p-locate": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/eslint-plugin-unicorn/node_modules/normalize-package-data": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
+      "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
+      "dev": true,
+      "dependencies": {
+        "hosted-git-info": "^2.1.4",
+        "resolve": "^1.10.0",
+        "semver": "2 || 3 || 4 || 5",
+        "validate-npm-package-license": "^3.0.1"
+      }
+    },
+    "node_modules/eslint-plugin-unicorn/node_modules/normalize-package-data/node_modules/semver": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver"
+      }
+    },
+    "node_modules/eslint-plugin-unicorn/node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "dev": true,
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint-plugin-unicorn/node_modules/p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "dev": true,
+      "dependencies": {
+        "p-limit": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/eslint-plugin-unicorn/node_modules/parse-json": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+      "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.0.0",
+        "error-ex": "^1.3.1",
+        "json-parse-even-better-errors": "^2.3.0",
+        "lines-and-columns": "^1.1.6"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint-plugin-unicorn/node_modules/read-pkg": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-5.2.0.tgz",
+      "integrity": "sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==",
+      "dev": true,
+      "dependencies": {
+        "@types/normalize-package-data": "^2.4.0",
+        "normalize-package-data": "^2.5.0",
+        "parse-json": "^5.0.0",
+        "type-fest": "^0.6.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/eslint-plugin-unicorn/node_modules/read-pkg-up": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-7.0.1.tgz",
+      "integrity": "sha512-zK0TB7Xd6JpCLmlLmufqykGE+/TlOePD6qKClNW7hHDKFh/J7/7gCWGR7joEQEW1bKq3a3yUZSObOoWLFQ4ohg==",
+      "dev": true,
+      "dependencies": {
+        "find-up": "^4.1.0",
+        "read-pkg": "^5.2.0",
+        "type-fest": "^0.8.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint-plugin-unicorn/node_modules/read-pkg/node_modules/type-fest": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.6.0.tgz",
+      "integrity": "sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/eslint-plugin-unicorn/node_modules/type-fest": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
+      "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/eslint-scope": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
@@ -2437,6 +3073,31 @@
       },
       "engines": {
         "node": ">=8.0.0"
+      }
+    },
+    "node_modules/eslint-template-visitor": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/eslint-template-visitor/-/eslint-template-visitor-2.3.2.tgz",
+      "integrity": "sha512-3ydhqFpuV7x1M9EK52BPNj6V0Kwu0KKkcIAfpUhwHbR8ocRln/oUHgfxQupY8O1h4Qv/POHDumb/BwwNfxbtnA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/core": "^7.12.16",
+        "@babel/eslint-parser": "^7.12.16",
+        "eslint-visitor-keys": "^2.0.0",
+        "esquery": "^1.3.1",
+        "multimap": "^1.1.0"
+      },
+      "peerDependencies": {
+        "eslint": ">=7.0.0"
+      }
+    },
+    "node_modules/eslint-template-visitor/node_modules/eslint-visitor-keys": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
+      "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/eslint-utils": {
@@ -3024,6 +3685,15 @@
         "node": ">=4"
       }
     },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/get-caller-file": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
@@ -3434,6 +4104,18 @@
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
       "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ=="
     },
+    "node_modules/is-builtin-module": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-3.1.0.tgz",
+      "integrity": "sha512-OV7JjAgOTfAFJmHZLvpSTb4qi0nIILDV1gWPYDnDJUTNFM5aGlRAhk4QcT8i7TuAleeEV5Fdkqn3t4mS+Q11fg==",
+      "dev": true,
+      "dependencies": {
+        "builtin-modules": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/is-core-module": {
       "version": "2.8.0",
       "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.8.0.tgz",
@@ -3552,6 +4234,18 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
+    "node_modules/jsesc": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
+      "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
+      "dev": true,
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/json-parse-better-errors": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
@@ -3581,6 +4275,21 @@
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
       "dev": true
+    },
+    "node_modules/json5": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.0.tgz",
+      "integrity": "sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==",
+      "dev": true,
+      "dependencies": {
+        "minimist": "^1.2.5"
+      },
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/jsonfile": {
       "version": "6.1.0",
@@ -4181,6 +4890,12 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
+    "node_modules/multimap": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/multimap/-/multimap-1.1.0.tgz",
+      "integrity": "sha512-0ZIR9PasPxGXmRsEF8jsDzndzHDj7tIav+JUmvIFB/WHswliFnquxECT/De7GR4yg99ky/NlRKJT82G1y271bw==",
+      "dev": true
+    },
     "node_modules/nan": {
       "version": "2.15.0",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.15.0.tgz",
@@ -4247,6 +4962,12 @@
         "node-gyp-build-optional": "optional.js",
         "node-gyp-build-test": "build-test.js"
       }
+    },
+    "node_modules/node-releases": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.1.tgz",
+      "integrity": "sha512-CqyzN6z7Q6aMeF/ktcMVTzhAHCEpf8SOarwpzpf8pNBY2k5/oM34UHldUwp8VKI7uxct2HxSRdJjBaZeESzcxA==",
+      "dev": true
     },
     "node_modules/nopt": {
       "version": "5.0.0",
@@ -4505,6 +5226,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/picocolors": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
+      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
+      "dev": true
+    },
     "node_modules/picomatch": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
@@ -4524,6 +5251,15 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/pluralize": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-8.0.0.tgz",
+      "integrity": "sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/prelude-ls": {
@@ -4843,6 +5579,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/regexp-tree": {
+      "version": "0.1.24",
+      "resolved": "https://registry.npmjs.org/regexp-tree/-/regexp-tree-0.1.24.tgz",
+      "integrity": "sha512-s2aEVuLhvnVJW6s/iPgEGK6R+/xngd2jNQ+xy4bXNDKxZKJH6jpPHY6kVeVv1IeLCHgswRj+Kl3ELaDjG6V1iw==",
+      "dev": true,
+      "bin": {
+        "regexp-tree": "bin/regexp-tree"
+      }
+    },
     "node_modules/regexpp": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz",
@@ -4937,6 +5682,15 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+    },
+    "node_modules/safe-regex": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-2.1.1.tgz",
+      "integrity": "sha512-rx+x8AMzKb5Q5lQ95Zoi6ZbJqwCLkqi3XuJXp5P3rT8OEc6sZCJG5AE5dU3lsgRr/F4Bs31jSlVN+j5KrsGu9A==",
+      "dev": true,
+      "dependencies": {
+        "regexp-tree": "~0.1.1"
+      }
     },
     "node_modules/safe-stable-stringify": {
       "version": "1.1.1",
@@ -5539,6 +6293,15 @@
       "resolved": "https://registry.npmjs.org/tiny-typed-emitter/-/tiny-typed-emitter-2.1.0.tgz",
       "integrity": "sha512-qVtvMxeXbVej0cQWKqVSSAHmKZEHAvxdF8HEUBFWts8h+xEo5m/lEiPakuyZ3BnCBjOD8i24kzNOiOLLgsSxhA=="
     },
+    "node_modules/to-fast-properties": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+      "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -6122,12 +6885,221 @@
   },
   "dependencies": {
     "@babel/code-frame": {
-      "version": "7.12.11",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.11.tgz",
-      "integrity": "sha512-Zt1yodBx1UcyiePMSkWnU4hPqhwq7hGi2nFL1LeA3EUl+q2LQx16MISgJ0+z7dnmgvP9QtIleuETGOiOH1RcIw==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.16.0.tgz",
+      "integrity": "sha512-IF4EOMEV+bfYwOmNxGzSnjR2EmQod7f1UXOpZM3l4i4o4QNwzjtJAu/HxdjHq0aYBvdqMuQEY1eg0nqW9ZPORA==",
       "dev": true,
       "requires": {
-        "@babel/highlight": "^7.10.4"
+        "@babel/highlight": "^7.16.0"
+      }
+    },
+    "@babel/compat-data": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.16.0.tgz",
+      "integrity": "sha512-DGjt2QZse5SGd9nfOSqO4WLJ8NN/oHkijbXbPrxuoJO3oIPJL3TciZs9FX+cOHNiY9E9l0opL8g7BmLe3T+9ew==",
+      "dev": true
+    },
+    "@babel/core": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.16.0.tgz",
+      "integrity": "sha512-mYZEvshBRHGsIAiyH5PzCFTCfbWfoYbO/jcSdXQSUQu1/pW0xDZAUP7KEc32heqWTAfAHhV9j1vH8Sav7l+JNQ==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.16.0",
+        "@babel/generator": "^7.16.0",
+        "@babel/helper-compilation-targets": "^7.16.0",
+        "@babel/helper-module-transforms": "^7.16.0",
+        "@babel/helpers": "^7.16.0",
+        "@babel/parser": "^7.16.0",
+        "@babel/template": "^7.16.0",
+        "@babel/traverse": "^7.16.0",
+        "@babel/types": "^7.16.0",
+        "convert-source-map": "^1.7.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.1.2",
+        "semver": "^6.3.0",
+        "source-map": "^0.5.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "dev": true
+        },
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+          "dev": true
+        }
+      }
+    },
+    "@babel/eslint-parser": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/eslint-parser/-/eslint-parser-7.16.0.tgz",
+      "integrity": "sha512-c+AsYOHjI+FgCa+ifLd8sDXp4U4mjkfFgL9NdQWhuA731kAUJs0WdJIXET4A14EJAR9Jv9FFF/MzPWJfV9Oirw==",
+      "dev": true,
+      "requires": {
+        "eslint-scope": "^5.1.1",
+        "eslint-visitor-keys": "^2.1.0",
+        "semver": "^6.3.0"
+      },
+      "dependencies": {
+        "eslint-visitor-keys": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
+          "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
+          "dev": true
+        },
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "dev": true
+        }
+      }
+    },
+    "@babel/generator": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.16.0.tgz",
+      "integrity": "sha512-RR8hUCfRQn9j9RPKEVXo9LiwoxLPYn6hNZlvUOR8tSnaxlD0p0+la00ZP9/SnRt6HchKr+X0fO2r8vrETiJGew==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.16.0",
+        "jsesc": "^2.5.1",
+        "source-map": "^0.5.0"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+          "dev": true
+        }
+      }
+    },
+    "@babel/helper-compilation-targets": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.16.0.tgz",
+      "integrity": "sha512-S7iaOT1SYlqK0sQaCi21RX4+13hmdmnxIEAnQUB/eh7GeAnRjOUgTYpLkUOiRXzD+yog1JxP0qyAQZ7ZxVxLVg==",
+      "dev": true,
+      "requires": {
+        "@babel/compat-data": "^7.16.0",
+        "@babel/helper-validator-option": "^7.14.5",
+        "browserslist": "^4.16.6",
+        "semver": "^6.3.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "dev": true
+        }
+      }
+    },
+    "@babel/helper-function-name": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.16.0.tgz",
+      "integrity": "sha512-BZh4mEk1xi2h4HFjWUXRQX5AEx4rvaZxHgax9gcjdLWdkjsY7MKt5p0otjsg5noXw+pB+clMCjw+aEVYADMjog==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-get-function-arity": "^7.16.0",
+        "@babel/template": "^7.16.0",
+        "@babel/types": "^7.16.0"
+      }
+    },
+    "@babel/helper-get-function-arity": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.16.0.tgz",
+      "integrity": "sha512-ASCquNcywC1NkYh/z7Cgp3w31YW8aojjYIlNg4VeJiHkqyP4AzIvr4qx7pYDb4/s8YcsZWqqOSxgkvjUz1kpDQ==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.16.0"
+      }
+    },
+    "@babel/helper-hoist-variables": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.16.0.tgz",
+      "integrity": "sha512-1AZlpazjUR0EQZQv3sgRNfM9mEVWPK3M6vlalczA+EECcPz3XPh6VplbErL5UoMpChhSck5wAJHthlj1bYpcmg==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.16.0"
+      }
+    },
+    "@babel/helper-member-expression-to-functions": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.16.0.tgz",
+      "integrity": "sha512-bsjlBFPuWT6IWhl28EdrQ+gTvSvj5tqVP5Xeftp07SEuz5pLnsXZuDkDD3Rfcxy0IsHmbZ+7B2/9SHzxO0T+sQ==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.16.0"
+      }
+    },
+    "@babel/helper-module-imports": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.16.0.tgz",
+      "integrity": "sha512-kkH7sWzKPq0xt3H1n+ghb4xEMP8k0U7XV3kkB+ZGy69kDk2ySFW1qPi06sjKzFY3t1j6XbJSqr4mF9L7CYVyhg==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.16.0"
+      }
+    },
+    "@babel/helper-module-transforms": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.16.0.tgz",
+      "integrity": "sha512-My4cr9ATcaBbmaEa8M0dZNA74cfI6gitvUAskgDtAFmAqyFKDSHQo5YstxPbN+lzHl2D9l/YOEFqb2mtUh4gfA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-module-imports": "^7.16.0",
+        "@babel/helper-replace-supers": "^7.16.0",
+        "@babel/helper-simple-access": "^7.16.0",
+        "@babel/helper-split-export-declaration": "^7.16.0",
+        "@babel/helper-validator-identifier": "^7.15.7",
+        "@babel/template": "^7.16.0",
+        "@babel/traverse": "^7.16.0",
+        "@babel/types": "^7.16.0"
+      }
+    },
+    "@babel/helper-optimise-call-expression": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.16.0.tgz",
+      "integrity": "sha512-SuI467Gi2V8fkofm2JPnZzB/SUuXoJA5zXe/xzyPP2M04686RzFKFHPK6HDVN6JvWBIEW8tt9hPR7fXdn2Lgpw==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.16.0"
+      }
+    },
+    "@babel/helper-replace-supers": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.16.0.tgz",
+      "integrity": "sha512-TQxuQfSCdoha7cpRNJvfaYxxxzmbxXw/+6cS7V02eeDYyhxderSoMVALvwupA54/pZcOTtVeJ0xccp1nGWladA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-member-expression-to-functions": "^7.16.0",
+        "@babel/helper-optimise-call-expression": "^7.16.0",
+        "@babel/traverse": "^7.16.0",
+        "@babel/types": "^7.16.0"
+      }
+    },
+    "@babel/helper-simple-access": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.16.0.tgz",
+      "integrity": "sha512-o1rjBT/gppAqKsYfUdfHq5Rk03lMQrkPHG1OWzHWpLgVXRH4HnMM9Et9CVdIqwkCQlobnGHEJMsgWP/jE1zUiw==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.16.0"
+      }
+    },
+    "@babel/helper-split-export-declaration": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.16.0.tgz",
+      "integrity": "sha512-0YMMRpuDFNGTHNRiiqJX19GjNXA4H0E8jZ2ibccfSxaCogbm3am5WN/2nQNj0YnQwGWM1J06GOcQ2qnh3+0paw==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.16.0"
       }
     },
     "@babel/helper-validator-identifier": {
@@ -6136,13 +7108,30 @@
       "integrity": "sha512-K4JvCtQqad9OY2+yTU8w+E82ywk/fe+ELNlt1G8z3bVGlZfn/hOcQQsUhGhW/N+tb3fxK800wLtKOE/aM0m72w==",
       "dev": true
     },
-    "@babel/highlight": {
+    "@babel/helper-validator-option": {
       "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.14.5.tgz",
-      "integrity": "sha512-qf9u2WFWVV0MppaL877j2dBtQIDgmidgjGk5VIMw3OadXvYaXn66U1BFlH2t4+t3i+8PhedppRv+i40ABzd+gg==",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.14.5.tgz",
+      "integrity": "sha512-OX8D5eeX4XwcroVW45NMvoYaIuFI+GQpA2a8Gi+X/U/cDUIRsV37qQfF905F0htTRCREQIB4KqPeaveRJUl3Ow==",
+      "dev": true
+    },
+    "@babel/helpers": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.16.0.tgz",
+      "integrity": "sha512-dVRM0StFMdKlkt7cVcGgwD8UMaBfWJHl3A83Yfs8GQ3MO0LHIIIMvK7Fa0RGOGUQ10qikLaX6D7o5htcQWgTMQ==",
       "dev": true,
       "requires": {
-        "@babel/helper-validator-identifier": "^7.14.5",
+        "@babel/template": "^7.16.0",
+        "@babel/traverse": "^7.16.0",
+        "@babel/types": "^7.16.0"
+      }
+    },
+    "@babel/highlight": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.16.0.tgz",
+      "integrity": "sha512-t8MH41kUQylBtu2+4IQA3atqevA2lRgqA2wyVB/YiWmsDSuylZZuXOUy9ric30hfzauEFfdsuk/eXTRrGrfd0g==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-validator-identifier": "^7.15.7",
         "chalk": "^2.0.0",
         "js-tokens": "^4.0.0"
       },
@@ -6203,6 +7192,58 @@
             "has-flag": "^3.0.0"
           }
         }
+      }
+    },
+    "@babel/parser": {
+      "version": "7.16.2",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.16.2.tgz",
+      "integrity": "sha512-RUVpT0G2h6rOZwqLDTrKk7ksNv7YpAilTnYe1/Q+eDjxEceRMKVWbCsX7t8h6C1qCFi/1Y8WZjcEPBAFG27GPw==",
+      "dev": true
+    },
+    "@babel/template": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.16.0.tgz",
+      "integrity": "sha512-MnZdpFD/ZdYhXwiunMqqgyZyucaYsbL0IrjoGjaVhGilz+x8YB++kRfygSOIj1yOtWKPlx7NBp+9I1RQSgsd5A==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.16.0",
+        "@babel/parser": "^7.16.0",
+        "@babel/types": "^7.16.0"
+      }
+    },
+    "@babel/traverse": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.16.0.tgz",
+      "integrity": "sha512-qQ84jIs1aRQxaGaxSysII9TuDaguZ5yVrEuC0BN2vcPlalwfLovVmCjbFDPECPXcYM/wLvNFfp8uDOliLxIoUQ==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.16.0",
+        "@babel/generator": "^7.16.0",
+        "@babel/helper-function-name": "^7.16.0",
+        "@babel/helper-hoist-variables": "^7.16.0",
+        "@babel/helper-split-export-declaration": "^7.16.0",
+        "@babel/parser": "^7.16.0",
+        "@babel/types": "^7.16.0",
+        "debug": "^4.1.0",
+        "globals": "^11.1.0"
+      },
+      "dependencies": {
+        "globals": {
+          "version": "11.12.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+          "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+          "dev": true
+        }
+      }
+    },
+    "@babel/types": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.16.0.tgz",
+      "integrity": "sha512-PJgg/k3SdLsGb3hhisFvtLOw5ts113klrpLuIPtCJIU+BB24fqq6lf8RWqKJEjzqXR9AEH1rIb5XTqwBHB+kQg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-validator-identifier": "^7.15.7",
+        "to-fast-properties": "^2.0.0"
       }
     },
     "@cspotcode/source-map-consumer": {
@@ -7062,6 +8103,19 @@
         "fill-range": "^7.0.1"
       }
     },
+    "browserslist": {
+      "version": "4.17.6",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.17.6.tgz",
+      "integrity": "sha512-uPgz3vyRTlEiCv4ee9KlsKgo2V6qPk7Jsn0KAn2OBqbqKo3iNcPEC1Ti6J4dwnz+aIRfEEEuOzC9IBk8tXUomw==",
+      "dev": true,
+      "requires": {
+        "caniuse-lite": "^1.0.30001274",
+        "electron-to-chromium": "^1.3.886",
+        "escalade": "^3.1.1",
+        "node-releases": "^2.0.1",
+        "picocolors": "^1.0.0"
+      }
+    },
     "bson": {
       "version": "4.5.3",
       "resolved": "https://registry.npmjs.org/bson/-/bson-4.5.3.tgz",
@@ -7093,6 +8147,12 @@
         "node-gyp-build": "^4.3.0"
       }
     },
+    "builtin-modules": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-3.2.0.tgz",
+      "integrity": "sha512-lGzLKcioL90C7wMczpkY0n/oART3MbBa8R9OFGE1rJxoVI86u4WAGfEk8Wjv10eKSyTHVGkSo3bvBylCEtk7LA==",
+      "dev": true
+    },
     "bytes": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.0.tgz",
@@ -7120,6 +8180,12 @@
         "quick-lru": "^4.0.1"
       }
     },
+    "caniuse-lite": {
+      "version": "1.0.30001275",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001275.tgz",
+      "integrity": "sha512-ihJVvj8RX0kn9GgP43HKhb5q9s2XQn4nEQhdldEJvZhCsuiB2XOq6fAMYQZaN6FPWfsr2qU0cdL0CSbETwbJAg==",
+      "dev": true
+    },
     "canvas": {
       "version": "2.8.0",
       "resolved": "https://registry.npmjs.org/canvas/-/canvas-2.8.0.tgz",
@@ -7143,6 +8209,29 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
       "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ=="
+    },
+    "ci-info": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.2.0.tgz",
+      "integrity": "sha512-dVqRX7fLUm8J6FgHJ418XuIgDLZDkYcDFTeL6TA2gt5WlIZUQrrH6EZrNClwT/H0FateUsZkGIOPRrLbP+PR9A==",
+      "dev": true
+    },
+    "clean-regexp": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/clean-regexp/-/clean-regexp-1.0.0.tgz",
+      "integrity": "sha1-jffHquUf02h06PjQW5GAvBGj/tc=",
+      "dev": true,
+      "requires": {
+        "escape-string-regexp": "^1.0.5"
+      },
+      "dependencies": {
+        "escape-string-regexp": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+          "dev": true
+        }
+      }
     },
     "cliui": {
       "version": "7.0.4",
@@ -7520,6 +8609,15 @@
         "q": "^1.5.1"
       }
     },
+    "convert-source-map": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.8.0.tgz",
+      "integrity": "sha512-+OQdjP49zViI/6i7nIJpA8rAl4sV/JdPfU9nZs3VqOwGIgizICvuN2ru6fMd+4llL0tar18UYJXfZ/TWtmhUjA==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "~5.1.1"
+      }
+    },
     "cookie": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.0.tgz",
@@ -7857,6 +8955,12 @@
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
     },
+    "electron-to-chromium": {
+      "version": "1.3.887",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.887.tgz",
+      "integrity": "sha512-QQUumrEjFDKSVYVdaeBmFdyQGoaV+fCSMyWHvfx/u22bRHSTeBQYt6P4jMY+gFd4kgKB9nqk7RMtWkDB49OYPA==",
+      "dev": true
+    },
     "emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
@@ -7996,6 +9100,143 @@
         }
       }
     },
+    "eslint-plugin-unicorn": {
+      "version": "37.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-unicorn/-/eslint-plugin-unicorn-37.0.1.tgz",
+      "integrity": "sha512-E1jq5u9ojnadisJcPi+hMXTGSiIzkIUMDvWsBudsCGXvKUB2aNSU2TcfyW2/jAS5A4ryBXfzxLykMxX1EdluSQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-validator-identifier": "^7.14.9",
+        "ci-info": "^3.2.0",
+        "clean-regexp": "^1.0.0",
+        "eslint-template-visitor": "^2.3.2",
+        "eslint-utils": "^3.0.0",
+        "esquery": "^1.4.0",
+        "indent-string": "4",
+        "is-builtin-module": "^3.1.0",
+        "lodash": "^4.17.21",
+        "pluralize": "^8.0.0",
+        "read-pkg-up": "^7.0.1",
+        "regexp-tree": "^0.1.23",
+        "safe-regex": "^2.1.1",
+        "semver": "^7.3.5",
+        "strip-indent": "^3.0.0"
+      },
+      "dependencies": {
+        "find-up": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+          "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+          "dev": true,
+          "requires": {
+            "locate-path": "^5.0.0",
+            "path-exists": "^4.0.0"
+          }
+        },
+        "hosted-git-info": {
+          "version": "2.8.9",
+          "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
+          "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
+          "dev": true
+        },
+        "locate-path": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+          "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+          "dev": true,
+          "requires": {
+            "p-locate": "^4.1.0"
+          }
+        },
+        "normalize-package-data": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
+          "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
+          "dev": true,
+          "requires": {
+            "hosted-git-info": "^2.1.4",
+            "resolve": "^1.10.0",
+            "semver": "2 || 3 || 4 || 5",
+            "validate-npm-package-license": "^3.0.1"
+          },
+          "dependencies": {
+            "semver": {
+              "version": "5.7.1",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+              "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+              "dev": true
+            }
+          }
+        },
+        "p-limit": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+          "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+          "dev": true,
+          "requires": {
+            "p-try": "^2.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+          "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+          "dev": true,
+          "requires": {
+            "p-limit": "^2.2.0"
+          }
+        },
+        "parse-json": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+          "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.0.0",
+            "error-ex": "^1.3.1",
+            "json-parse-even-better-errors": "^2.3.0",
+            "lines-and-columns": "^1.1.6"
+          }
+        },
+        "read-pkg": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-5.2.0.tgz",
+          "integrity": "sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==",
+          "dev": true,
+          "requires": {
+            "@types/normalize-package-data": "^2.4.0",
+            "normalize-package-data": "^2.5.0",
+            "parse-json": "^5.0.0",
+            "type-fest": "^0.6.0"
+          },
+          "dependencies": {
+            "type-fest": {
+              "version": "0.6.0",
+              "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.6.0.tgz",
+              "integrity": "sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==",
+              "dev": true
+            }
+          }
+        },
+        "read-pkg-up": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-7.0.1.tgz",
+          "integrity": "sha512-zK0TB7Xd6JpCLmlLmufqykGE+/TlOePD6qKClNW7hHDKFh/J7/7gCWGR7joEQEW1bKq3a3yUZSObOoWLFQ4ohg==",
+          "dev": true,
+          "requires": {
+            "find-up": "^4.1.0",
+            "read-pkg": "^5.2.0",
+            "type-fest": "^0.8.1"
+          }
+        },
+        "type-fest": {
+          "version": "0.8.1",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
+          "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+          "dev": true
+        }
+      }
+    },
     "eslint-scope": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
@@ -8004,6 +9245,27 @@
       "requires": {
         "esrecurse": "^4.3.0",
         "estraverse": "^4.1.1"
+      }
+    },
+    "eslint-template-visitor": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/eslint-template-visitor/-/eslint-template-visitor-2.3.2.tgz",
+      "integrity": "sha512-3ydhqFpuV7x1M9EK52BPNj6V0Kwu0KKkcIAfpUhwHbR8ocRln/oUHgfxQupY8O1h4Qv/POHDumb/BwwNfxbtnA==",
+      "dev": true,
+      "requires": {
+        "@babel/core": "^7.12.16",
+        "@babel/eslint-parser": "^7.12.16",
+        "eslint-visitor-keys": "^2.0.0",
+        "esquery": "^1.3.1",
+        "multimap": "^1.1.0"
+      },
+      "dependencies": {
+        "eslint-visitor-keys": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
+          "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
+          "dev": true
+        }
       }
     },
     "eslint-utils": {
@@ -8435,6 +9697,12 @@
         }
       }
     },
+    "gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "dev": true
+    },
     "get-caller-file": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
@@ -8736,6 +10004,15 @@
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
       "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ=="
     },
+    "is-builtin-module": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-3.1.0.tgz",
+      "integrity": "sha512-OV7JjAgOTfAFJmHZLvpSTb4qi0nIILDV1gWPYDnDJUTNFM5aGlRAhk4QcT8i7TuAleeEV5Fdkqn3t4mS+Q11fg==",
+      "dev": true,
+      "requires": {
+        "builtin-modules": "^3.0.0"
+      }
+    },
     "is-core-module": {
       "version": "2.8.0",
       "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.8.0.tgz",
@@ -8821,6 +10098,12 @@
         "argparse": "^2.0.1"
       }
     },
+    "jsesc": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
+      "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
+      "dev": true
+    },
     "json-parse-better-errors": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
@@ -8850,6 +10133,15 @@
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
       "dev": true
+    },
+    "json5": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.0.tgz",
+      "integrity": "sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==",
+      "dev": true,
+      "requires": {
+        "minimist": "^1.2.5"
+      }
     },
     "jsonfile": {
       "version": "6.1.0",
@@ -9297,6 +10589,12 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
+    "multimap": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/multimap/-/multimap-1.1.0.tgz",
+      "integrity": "sha512-0ZIR9PasPxGXmRsEF8jsDzndzHDj7tIav+JUmvIFB/WHswliFnquxECT/De7GR4yg99ky/NlRKJT82G1y271bw==",
+      "dev": true
+    },
     "nan": {
       "version": "2.15.0",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.15.0.tgz",
@@ -9342,6 +10640,12 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.3.0.tgz",
       "integrity": "sha512-iWjXZvmboq0ja1pUGULQBexmxq8CV4xBhX7VDOTbL7ZR4FOowwY/VOtRxBN/yKxmdGoIp4j5ysNT4u3S2pDQ3Q=="
+    },
+    "node-releases": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.1.tgz",
+      "integrity": "sha512-CqyzN6z7Q6aMeF/ktcMVTzhAHCEpf8SOarwpzpf8pNBY2k5/oM34UHldUwp8VKI7uxct2HxSRdJjBaZeESzcxA==",
+      "dev": true
     },
     "nopt": {
       "version": "5.0.0",
@@ -9530,6 +10834,12 @@
       "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
       "dev": true
     },
+    "picocolors": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
+      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
+      "dev": true
+    },
     "picomatch": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
@@ -9540,6 +10850,12 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
       "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+      "dev": true
+    },
+    "pluralize": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-8.0.0.tgz",
+      "integrity": "sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==",
       "dev": true
     },
     "prelude-ls": {
@@ -9775,6 +11091,12 @@
         "strip-indent": "^3.0.0"
       }
     },
+    "regexp-tree": {
+      "version": "0.1.24",
+      "resolved": "https://registry.npmjs.org/regexp-tree/-/regexp-tree-0.1.24.tgz",
+      "integrity": "sha512-s2aEVuLhvnVJW6s/iPgEGK6R+/xngd2jNQ+xy4bXNDKxZKJH6jpPHY6kVeVv1IeLCHgswRj+Kl3ELaDjG6V1iw==",
+      "dev": true
+    },
     "regexpp": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz",
@@ -9830,6 +11152,15 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+    },
+    "safe-regex": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-2.1.1.tgz",
+      "integrity": "sha512-rx+x8AMzKb5Q5lQ95Zoi6ZbJqwCLkqi3XuJXp5P3rT8OEc6sZCJG5AE5dU3lsgRr/F4Bs31jSlVN+j5KrsGu9A==",
+      "dev": true,
+      "requires": {
+        "regexp-tree": "~0.1.1"
+      }
     },
     "safe-stable-stringify": {
       "version": "1.1.1",
@@ -10309,6 +11640,12 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/tiny-typed-emitter/-/tiny-typed-emitter-2.1.0.tgz",
       "integrity": "sha512-qVtvMxeXbVej0cQWKqVSSAHmKZEHAvxdF8HEUBFWts8h+xEo5m/lEiPakuyZ3BnCBjOD8i24kzNOiOLLgsSxhA=="
+    },
+    "to-fast-properties": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+      "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+      "dev": true
     },
     "to-regex-range": {
       "version": "5.0.1",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,15 @@
     "type": "git",
     "url": "git+https://github.com/LonelessCodes/Soundbort.git"
   },
+  "bugs": {
+    "url": "https://github.com/LonelessCodes/Soundbort/issues"
+  },
+  "license": "GPL-3.0",
+  "keywords": [
+    "discord",
+    "bot",
+    "soundboard"
+  ],
   "dependencies": {
     "@discordjs/builders": "^0.8.1",
     "@discordjs/collection": "^0.3.1",
@@ -78,14 +87,6 @@
     "release:patch": "standard-version --release-as patch",
     "health": "curl -f http://localhost:6969/ || exit 1"
   },
-  "license": "GPL-3.0",
-  "keywords": [
-    "discord",
-    "bot",
-    "soundboard"
-  ],
-  "main": "dist/index.js",
-  "bugs": {
-    "url": "https://github.com/LonelessCodes/Soundbort/issues"
-  }
+  "type": "module",
+  "main": "dist/index.js"
 }

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "soundboard"
   ],
   "dependencies": {
-    "@discordjs/builders": "^0.7.0",
+    "@discordjs/builders": "=0.7.0",
     "@discordjs/collection": "^0.3.1",
     "@discordjs/opus": "^0.6.0",
     "@discordjs/voice": "^0.6.0",
@@ -62,6 +62,7 @@
     "@typescript-eslint/eslint-plugin": "^5.2.0",
     "@typescript-eslint/parser": "^5.2.0",
     "eslint": "^8.1.0",
+    "eslint-plugin-unicorn": "^37.0.1",
     "rimraf": "^3.0.2",
     "standard-version": "^9.3.1",
     "ts-node": "^10.1.0",
@@ -77,7 +78,7 @@
     "lint": "eslint src/ --ext .ts,.js",
     "lint:fix": "eslint src/ --ext .ts,.js --fix",
     "start:docker": "docker run $(for var in $(cat .env); do echo \"-e $var\"; done) loneless/soundbort",
-    "start:watch": "NODE_ENV=development node --loader node-ts/esm src/index.ts",
+    "start:watch": "NODE_ENV=development node --loader ts-node/esm src/index.ts",
     "start:devel": "NODE_ENV=development node --unhandled-rejections=strict dist/index.js",
     "start": "NODE_ENV=production node dist/index.js",
     "release": "standard-version",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "soundboard"
   ],
   "dependencies": {
-    "@discordjs/builders": "^0.8.1",
+    "@discordjs/builders": "^0.7.0",
     "@discordjs/collection": "^0.3.1",
     "@discordjs/opus": "^0.6.0",
     "@discordjs/voice": "^0.6.0",
@@ -32,13 +32,13 @@
     "discord.js": "^13.3.1",
     "diskusage": "^1.1.3",
     "dotenv": "^10.0.0",
-    "escape-string-regexp": "^4.0.0",
+    "escape-string-regexp": "^5.0.0",
     "express": "^4.17.1",
     "fluent-ffmpeg": "^2.1.2",
     "fs-extra": "^10.0.0",
     "mongodb": "^4.1.2",
     "nanoid": "^3.1.23",
-    "node-fetch": "^2.6.2",
+    "node-fetch": "^3.0.0",
     "query-string": "^7.0.1",
     "sodium": "^3.0.2",
     "temp": "^0.9.4",
@@ -57,7 +57,6 @@
     "@types/fs-extra": "^9.0.12",
     "@types/mime": "^2.0.3",
     "@types/node": "^16.9.1",
-    "@types/node-fetch": "^2.5.12",
     "@types/temp": "^0.9.1",
     "@types/tmp": "^0.2.1",
     "@typescript-eslint/eslint-plugin": "^5.2.0",
@@ -78,7 +77,7 @@
     "lint": "eslint src/ --ext .ts,.js",
     "lint:fix": "eslint src/ --ext .ts,.js --fix",
     "start:docker": "docker run $(for var in $(cat .env); do echo \"-e $var\"; done) loneless/soundbort",
-    "start:watch": "NODE_ENV=development ts-node --project tsconfig.json src/index.ts",
+    "start:watch": "NODE_ENV=development node --loader node-ts/esm src/index.ts",
     "start:devel": "NODE_ENV=development node --unhandled-rejections=strict dist/index.js",
     "start": "NODE_ENV=production node dist/index.js",
     "release": "standard-version",
@@ -87,6 +86,5 @@
     "release:patch": "standard-version --release-as patch",
     "health": "curl -f http://localhost:6969/ || exit 1"
   },
-  "type": "module",
-  "main": "dist/index.js"
+  "type": "module"
 }

--- a/src/commands/audio/join.ts
+++ b/src/commands/audio/join.ts
@@ -1,9 +1,10 @@
 import Discord from "discord.js";
 
-import AudioManager, { JoinFailureTypes } from "../../core/audio/AudioManager.js";
 import InteractionRegistry from "../../core/InteractionRegistry.js";
 import { TopCommand } from "../../modules/commands/TopCommand.js";
 import { EmbedType, replyEmbed, replyEmbedEphemeral } from "../../util/builders/embed.js";
+
+import AudioManager, { JoinFailureTypes } from "../../core/audio/AudioManager.js";
 
 InteractionRegistry.addCommand(new TopCommand({
     name: "join",

--- a/src/commands/audio/join.ts
+++ b/src/commands/audio/join.ts
@@ -1,9 +1,9 @@
 import Discord from "discord.js";
 
-import AudioManager, { JoinFailureTypes } from "../../core/audio/AudioManager";
-import InteractionRegistry from "../../core/InteractionRegistry";
-import { TopCommand } from "../../modules/commands/TopCommand";
-import { EmbedType, replyEmbed, replyEmbedEphemeral } from "../../util/builders/embed";
+import AudioManager, { JoinFailureTypes } from "../../core/audio/AudioManager.js";
+import InteractionRegistry from "../../core/InteractionRegistry.js";
+import { TopCommand } from "../../modules/commands/TopCommand.js";
+import { EmbedType, replyEmbed, replyEmbedEphemeral } from "../../util/builders/embed.js";
 
 InteractionRegistry.addCommand(new TopCommand({
     name: "join",

--- a/src/commands/audio/leave.ts
+++ b/src/commands/audio/leave.ts
@@ -1,9 +1,9 @@
 import Discord from "discord.js";
 
-import AudioManager from "../../core/audio/AudioManager";
-import InteractionRegistry from "../../core/InteractionRegistry";
-import { TopCommand } from "../../modules/commands/TopCommand";
-import { EmbedType, replyEmbed, replyEmbedEphemeral } from "../../util/builders/embed";
+import AudioManager from "../../core/audio/AudioManager.js";
+import InteractionRegistry from "../../core/InteractionRegistry.js";
+import { TopCommand } from "../../modules/commands/TopCommand.js";
+import { EmbedType, replyEmbed, replyEmbedEphemeral } from "../../util/builders/embed.js";
 
 InteractionRegistry.addCommand(new TopCommand({
     name: "leave",

--- a/src/commands/audio/leave.ts
+++ b/src/commands/audio/leave.ts
@@ -1,9 +1,10 @@
 import Discord from "discord.js";
 
-import AudioManager from "../../core/audio/AudioManager.js";
 import InteractionRegistry from "../../core/InteractionRegistry.js";
 import { TopCommand } from "../../modules/commands/TopCommand.js";
 import { EmbedType, replyEmbed, replyEmbedEphemeral } from "../../util/builders/embed.js";
+
+import AudioManager from "../../core/audio/AudioManager.js";
 
 InteractionRegistry.addCommand(new TopCommand({
     name: "leave",

--- a/src/commands/audio/stop.ts
+++ b/src/commands/audio/stop.ts
@@ -1,9 +1,10 @@
 import Discord from "discord.js";
 
-import AudioManager from "../../core/audio/AudioManager.js";
 import InteractionRegistry from "../../core/InteractionRegistry.js";
 import { TopCommand } from "../../modules/commands/TopCommand.js";
 import { EmbedType, replyEmbed, replyEmbedEphemeral } from "../../util/builders/embed.js";
+
+import AudioManager from "../../core/audio/AudioManager.js";
 
 InteractionRegistry.addCommand(new TopCommand({
     name: "stop",

--- a/src/commands/audio/stop.ts
+++ b/src/commands/audio/stop.ts
@@ -1,9 +1,9 @@
 import Discord from "discord.js";
 
-import AudioManager from "../../core/audio/AudioManager";
-import InteractionRegistry from "../../core/InteractionRegistry";
-import { TopCommand } from "../../modules/commands/TopCommand";
-import { EmbedType, replyEmbed, replyEmbedEphemeral } from "../../util/builders/embed";
+import AudioManager from "../../core/audio/AudioManager.js";
+import InteractionRegistry from "../../core/InteractionRegistry.js";
+import { TopCommand } from "../../modules/commands/TopCommand.js";
+import { EmbedType, replyEmbed, replyEmbedEphemeral } from "../../util/builders/embed.js";
 
 InteractionRegistry.addCommand(new TopCommand({
     name: "stop",

--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -1,10 +1,10 @@
-import InteractionRegistry from "../core/InteractionRegistry";
-import { CommandRoleOption } from "../modules/commands/CommandOption";
-import { TopCommandGroup } from "../modules/commands/TopCommandGroup";
-import { Command } from "../modules/commands/Command";
-import { BOT_NAME } from "../config";
-import { EmbedType, replyEmbed } from "../util/builders/embed";
-import GuildConfigManager from "../core/managers/GuildConfigManager";
+import InteractionRegistry from "../core/InteractionRegistry.js";
+import { CommandRoleOption } from "../modules/commands/CommandOption.js";
+import { TopCommandGroup } from "../modules/commands/TopCommandGroup.js";
+import { Command } from "../modules/commands/Command.js";
+import { BOT_NAME } from "../config.js";
+import { EmbedType, replyEmbed } from "../util/builders/embed.js";
+import GuildConfigManager from "../core/managers/GuildConfigManager.js";
 
 const set_admin_role_cmd = new Command({
     name: "set-admin-role",

--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -1,9 +1,11 @@
+import { BOT_NAME } from "../config.js";
+
 import InteractionRegistry from "../core/InteractionRegistry.js";
+import { EmbedType, replyEmbed } from "../util/builders/embed.js";
 import { CommandRoleOption } from "../modules/commands/CommandOption.js";
 import { TopCommandGroup } from "../modules/commands/TopCommandGroup.js";
 import { Command } from "../modules/commands/Command.js";
-import { BOT_NAME } from "../config.js";
-import { EmbedType, replyEmbed } from "../util/builders/embed.js";
+
 import GuildConfigManager from "../core/managers/GuildConfigManager.js";
 
 const set_admin_role_cmd = new Command({

--- a/src/commands/getting-started.ts
+++ b/src/commands/getting-started.ts
@@ -1,8 +1,8 @@
-import { BOT_NAME, VERSION } from "../config";
-import InteractionRegistry from "../core/InteractionRegistry";
-import { TopCommand } from "../modules/commands/TopCommand";
-import { CmdInstallerArgs } from "../util/types";
-import { createEmbed } from "../util/builders/embed";
+import { BOT_NAME, VERSION } from "../config.js";
+import InteractionRegistry from "../core/InteractionRegistry.js";
+import { TopCommand } from "../modules/commands/TopCommand.js";
+import { CmdInstallerArgs } from "../util/types.js";
+import { createEmbed } from "../util/builders/embed.js";
 
 export function install({ client }: CmdInstallerArgs): void {
     const invite_link = `https://discord.com/api/oauth2/authorize?client_id=${client.user.id}&permissions=2150943744&scope=bot%20applications.commands&redirect_uri=https%3A%2F%2Fsoundbort-guide.loneless.art%2F`;

--- a/src/commands/getting-started.ts
+++ b/src/commands/getting-started.ts
@@ -1,8 +1,9 @@
 import { BOT_NAME, VERSION } from "../config.js";
-import InteractionRegistry from "../core/InteractionRegistry.js";
-import { TopCommand } from "../modules/commands/TopCommand.js";
+
 import { CmdInstallerArgs } from "../util/types.js";
 import { createEmbed } from "../util/builders/embed.js";
+import { TopCommand } from "../modules/commands/TopCommand.js";
+import InteractionRegistry from "../core/InteractionRegistry.js";
 
 export function install({ client }: CmdInstallerArgs): void {
     const invite_link = `https://discord.com/api/oauth2/authorize?client_id=${client.user.id}&permissions=2150943744&scope=bot%20applications.commands&redirect_uri=https%3A%2F%2Fsoundbort-guide.loneless.art%2F`;

--- a/src/commands/metrics.ts
+++ b/src/commands/metrics.ts
@@ -4,16 +4,18 @@ import color from "color";
 import os from "node:os";
 import { time } from "@discordjs/builders";
 
-import InteractionRegistry from "../core/InteractionRegistry.js";
+import { BUTTON_TYPES, BUTTON_TYPES_NAMES, COLOR } from "../const.js";
 import { BOT_NAME, VERSION } from "../config.js";
+
+import InteractionRegistry from "../core/InteractionRegistry.js";
 import { TopCommand } from "../modules/commands/TopCommand.js";
-import { createEmbed, EmbedType, replyEmbedEphemeral } from "../util/builders/embed.js";
+import { EmbedType, createEmbed, replyEmbedEphemeral } from "../util/builders/embed.js";
 import { CmdInstallerArgs } from "../util/types.js";
 import { CommandStringOption } from "../modules/commands/CommandOption.js";
 import { createChoice } from "../modules/commands/options/createChoice.js";
+
 import { ChartOptionsData } from "../modules/charts/line.js";
 import charts from "../modules/charts/index.js";
-import { BUTTON_TYPES, BUTTON_TYPES_NAMES, COLOR } from "../const.js";
 
 enum TimeWindowChoices {
     Day = "24 hours",

--- a/src/commands/metrics.ts
+++ b/src/commands/metrics.ts
@@ -1,19 +1,19 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 import Discord from "discord.js";
 import color from "color";
-import os from "os";
+import os from "node:os";
 import { time } from "@discordjs/builders";
 
-import InteractionRegistry from "../core/InteractionRegistry";
-import { BOT_NAME, VERSION } from "../config";
-import { TopCommand } from "../modules/commands/TopCommand";
-import { createEmbed, EmbedType, replyEmbedEphemeral } from "../util/builders/embed";
-import { CmdInstallerArgs } from "../util/types";
-import { CommandStringOption } from "../modules/commands/CommandOption";
-import { createChoice } from "../modules/commands/options/createChoice";
-import type { ChartOptionsData } from "../modules/charts/line";
-import charts from "../modules/charts";
-import { BUTTON_TYPES, BUTTON_TYPES_NAMES, COLOR } from "../const";
+import InteractionRegistry from "../core/InteractionRegistry.js";
+import { BOT_NAME, VERSION } from "../config.js";
+import { TopCommand } from "../modules/commands/TopCommand.js";
+import { createEmbed, EmbedType, replyEmbedEphemeral } from "../util/builders/embed.js";
+import { CmdInstallerArgs } from "../util/types.js";
+import { CommandStringOption } from "../modules/commands/CommandOption.js";
+import { createChoice } from "../modules/commands/options/createChoice.js";
+import { ChartOptionsData } from "../modules/charts/line.js";
+import charts from "../modules/charts/index.js";
+import { BUTTON_TYPES, BUTTON_TYPES_NAMES, COLOR } from "../const.js";
 
 enum TimeWindowChoices {
     Day = "24 hours",

--- a/src/commands/metrics.ts
+++ b/src/commands/metrics.ts
@@ -103,7 +103,7 @@ export function install({ stats_collector }: CmdInstallerArgs): void {
             embeds.push(createEmbed(`**Last updated**: ${time(aggregation._id, "R")}`)
                 .setAuthor(BOT_NAME, (interaction.client as Discord.Client<true>).user.avatarURL({ size: 32, dynamic: true }) || undefined)
                 .addField("Bot Version", VERSION, true)
-                .addField("Node.js Version", process.version.substr(1), true)
+                .addField("Node.js Version", process.version.slice(1), true)
                 .addField("Discord.js Version", Discord.version, true)
 
                 .addField("Uptime", time(new Date(Date.now() - Math.round(process.uptime() * 1000)), "R"), true)

--- a/src/commands/owner/owner.ts
+++ b/src/commands/owner/owner.ts
@@ -1,9 +1,10 @@
 import Discord from "discord.js";
 
-import { OWNER_IDS, OWNER_GUILD_IDS } from "../../config.js";
+import { OWNER_GUILD_IDS, OWNER_IDS } from "../../config.js";
 import { isOwner } from "../../util/util.js";
-import { EmbedType, replyEmbedEphemeral } from "../../util/builders/embed.js";
+
 import InteractionRegistry from "../../core/InteractionRegistry.js";
+import { EmbedType, replyEmbedEphemeral } from "../../util/builders/embed.js";
 import { TopCommandGroup } from "../../modules/commands/TopCommandGroup.js";
 import { createUserPermission } from "../../modules/commands/options/createPermission.js";
 

--- a/src/commands/owner/owner.ts
+++ b/src/commands/owner/owner.ts
@@ -1,19 +1,19 @@
 import Discord from "discord.js";
 
-import { OWNER_IDS, OWNER_GUILD_IDS } from "../../config";
-import { isOwner } from "../../util/util";
-import { EmbedType, replyEmbedEphemeral } from "../../util/builders/embed";
-import InteractionRegistry from "../../core/InteractionRegistry";
-import { TopCommandGroup } from "../../modules/commands/TopCommandGroup";
-import { createUserPermission } from "../../modules/commands/options/createPermission";
+import { OWNER_IDS, OWNER_GUILD_IDS } from "../../config.js";
+import { isOwner } from "../../util/util.js";
+import { EmbedType, replyEmbedEphemeral } from "../../util/builders/embed.js";
+import InteractionRegistry from "../../core/InteractionRegistry.js";
+import { TopCommandGroup } from "../../modules/commands/TopCommandGroup.js";
+import { createUserPermission } from "../../modules/commands/options/createPermission.js";
 
 // import commands. We can do this, because they don't register any commands by themselves,
 // so if they're already imported by the Core it doesn't matter
-import reboot_cmd from "./owner_reboot";
-import blacklist_cmd from "./owner_blacklist";
-import upload_standard_cmd from "./owner_upload";
-import delete_cmd from "./owner_delete";
-import import_cmd from "./owner_import";
+import reboot_cmd from "./owner_reboot.js";
+import blacklist_cmd from "./owner_blacklist.js";
+import upload_standard_cmd from "./owner_upload.js";
+import delete_cmd from "./owner_delete.js";
+import import_cmd from "./owner_import.js";
 
 InteractionRegistry.addCommand(new TopCommandGroup({
     name: "owner",

--- a/src/commands/owner/owner_blacklist.ts
+++ b/src/commands/owner/owner_blacklist.ts
@@ -1,8 +1,9 @@
 import { Command } from "../../modules/commands/Command.js";
 import { CommandGroup } from "../../modules/commands/CommandGroup.js";
 import { CommandStringOption } from "../../modules/commands/CommandOption.js";
-import * as models from "../../modules/database/models.js";
 import { EmbedType, replyEmbedEphemeral } from "../../util/builders/embed.js";
+
+import * as models from "../../modules/database/models.js";
 
 const blacklist_add_cmd = new Command({
     name: "add",

--- a/src/commands/owner/owner_blacklist.ts
+++ b/src/commands/owner/owner_blacklist.ts
@@ -1,8 +1,8 @@
-import { Command } from "../../modules/commands/Command";
-import { CommandGroup } from "../../modules/commands/CommandGroup";
-import { CommandStringOption } from "../../modules/commands/CommandOption";
-import * as models from "../../modules/database/models";
-import { EmbedType, replyEmbedEphemeral } from "../../util/builders/embed";
+import { Command } from "../../modules/commands/Command.js";
+import { CommandGroup } from "../../modules/commands/CommandGroup.js";
+import { CommandStringOption } from "../../modules/commands/CommandOption.js";
+import * as models from "../../modules/database/models.js";
+import { EmbedType, replyEmbedEphemeral } from "../../util/builders/embed.js";
 
 const blacklist_add_cmd = new Command({
     name: "add",

--- a/src/commands/owner/owner_delete.ts
+++ b/src/commands/owner/owner_delete.ts
@@ -1,11 +1,11 @@
-import { Command } from "../../modules/commands/Command";
-import { CommandGroup } from "../../modules/commands/CommandGroup";
-import { CommandStringOption } from "../../modules/commands/CommandOption";
-import { EmbedType, replyEmbed, replyEmbedEphemeral } from "../../util/builders/embed";
+import { Command } from "../../modules/commands/Command.js";
+import { CommandGroup } from "../../modules/commands/CommandGroup.js";
+import { CommandStringOption } from "../../modules/commands/CommandOption.js";
+import { EmbedType, replyEmbed, replyEmbedEphemeral } from "../../util/builders/embed.js";
 
-import { CustomSample } from "../../core/soundboard/CustomSample";
-import { StandardSample } from "../../core/soundboard/StandardSample";
-import { searchStandard } from "../../core/soundboard/methods/searchMany";
+import { CustomSample } from "../../core/soundboard/CustomSample.js";
+import { StandardSample } from "../../core/soundboard/StandardSample.js";
+import { searchStandard } from "../../core/soundboard/methods/searchMany.js";
 
 const delete_extern_cmd = new Command({
     name: "extern",

--- a/src/commands/owner/owner_import.ts
+++ b/src/commands/owner/owner_import.ts
@@ -1,8 +1,9 @@
 import { EmbedType, replyEmbedEphemeral } from "../../util/builders/embed.js";
 import { CommandStringOption } from "../../modules/commands/CommandOption.js";
+import { Command } from "../../modules/commands/Command.js";
+
 import { CustomSample } from "../../core/soundboard/CustomSample.js";
 import { StandardSample } from "../../core/soundboard/StandardSample.js";
-import { Command } from "../../modules/commands/Command.js";
 import { UploadErrors } from "../../core/soundboard/methods/upload.js";
 
 export default new Command({

--- a/src/commands/owner/owner_import.ts
+++ b/src/commands/owner/owner_import.ts
@@ -1,9 +1,9 @@
-import { EmbedType, replyEmbedEphemeral } from "../../util/builders/embed";
-import { CommandStringOption } from "../../modules/commands/CommandOption";
-import { CustomSample } from "../../core/soundboard/CustomSample";
-import { StandardSample } from "../../core/soundboard/StandardSample";
-import { Command } from "../../modules/commands/Command";
-import { UploadErrors } from "../../core/soundboard/methods/upload";
+import { EmbedType, replyEmbedEphemeral } from "../../util/builders/embed.js";
+import { CommandStringOption } from "../../modules/commands/CommandOption.js";
+import { CustomSample } from "../../core/soundboard/CustomSample.js";
+import { StandardSample } from "../../core/soundboard/StandardSample.js";
+import { Command } from "../../modules/commands/Command.js";
+import { UploadErrors } from "../../core/soundboard/methods/upload.js";
 
 export default new Command({
     name: "import",

--- a/src/commands/owner/owner_reboot.ts
+++ b/src/commands/owner/owner_reboot.ts
@@ -1,10 +1,10 @@
-import Logger from "../../log";
-import { exit } from "../../util/exit";
-import { logErr } from "../../util/util";
-import { replyEmbed } from "../../util/builders/embed";
-import { Command } from "../../modules/commands/Command";
-import { CommandBooleanOption } from "../../modules/commands/CommandOption";
-import AudioManager from "../../core/audio/AudioManager";
+import Logger from "../../log.js";
+import { exit } from "../../util/exit.js";
+import { logErr } from "../../util/util.js";
+import { replyEmbed } from "../../util/builders/embed.js";
+import { Command } from "../../modules/commands/Command.js";
+import { CommandBooleanOption } from "../../modules/commands/CommandOption.js";
+import AudioManager from "../../core/audio/AudioManager.js";
 
 const log = Logger.child({ label: "Reboot" });
 

--- a/src/commands/owner/owner_reboot.ts
+++ b/src/commands/owner/owner_reboot.ts
@@ -1,9 +1,11 @@
 import Logger from "../../log.js";
 import { exit } from "../../util/exit.js";
 import { logErr } from "../../util/util.js";
+
 import { replyEmbed } from "../../util/builders/embed.js";
 import { Command } from "../../modules/commands/Command.js";
 import { CommandBooleanOption } from "../../modules/commands/CommandOption.js";
+
 import AudioManager from "../../core/audio/AudioManager.js";
 
 const log = Logger.child({ label: "Reboot" });

--- a/src/commands/owner/owner_reboot.ts
+++ b/src/commands/owner/owner_reboot.ts
@@ -28,7 +28,7 @@ function shutdown(force: boolean) {
             log.debug("In no more voice connections. Shutting down.");
             exit(0);
         })
-        .catch(err => log.error("Error in AudioManager#awaitDestroyable", { error: logErr(err) }));
+        .catch(error => log.error("Error in AudioManager#awaitDestroyable", { error: logErr(error) }));
 
     log.info("Queued shutdown");
 

--- a/src/commands/owner/owner_upload.ts
+++ b/src/commands/owner/owner_upload.ts
@@ -3,6 +3,7 @@ import { SAMPLE_TYPES } from "../../const.js";
 import { Command } from "../../modules/commands/Command.js";
 import { CommandGroup } from "../../modules/commands/CommandGroup.js";
 import { CommandStringOption } from "../../modules/commands/CommandOption.js";
+
 import { upload } from "../../core/soundboard/methods/upload.js";
 
 export default new CommandGroup({

--- a/src/commands/owner/owner_upload.ts
+++ b/src/commands/owner/owner_upload.ts
@@ -1,9 +1,9 @@
-import { SAMPLE_TYPES } from "../../const";
+import { SAMPLE_TYPES } from "../../const.js";
 
-import { Command } from "../../modules/commands/Command";
-import { CommandGroup } from "../../modules/commands/CommandGroup";
-import { CommandStringOption } from "../../modules/commands/CommandOption";
-import { upload } from "../../core/soundboard/methods/upload";
+import { Command } from "../../modules/commands/Command.js";
+import { CommandGroup } from "../../modules/commands/CommandGroup.js";
+import { CommandStringOption } from "../../modules/commands/CommandOption.js";
+import { upload } from "../../core/soundboard/methods/upload.js";
 
 export default new CommandGroup({
     name: "upload",

--- a/src/commands/soundboard/delete.ts
+++ b/src/commands/soundboard/delete.ts
@@ -1,17 +1,17 @@
 import Discord from "discord.js";
 
-import { BUTTON_TYPES } from "../../const";
+import { BUTTON_TYPES } from "../../const.js";
 
-import InteractionRegistry from "../../core/InteractionRegistry";
-import { CommandStringOption } from "../../modules/commands/CommandOption";
-import { TopCommand } from "../../modules/commands/TopCommand";
-import { EmbedType, replyEmbed, replyEmbedEphemeral } from "../../util/builders/embed";
+import InteractionRegistry from "../../core/InteractionRegistry.js";
+import { CommandStringOption } from "../../modules/commands/CommandOption.js";
+import { TopCommand } from "../../modules/commands/TopCommand.js";
+import { EmbedType, replyEmbed, replyEmbedEphemeral } from "../../util/builders/embed.js";
 
-import { CustomSample } from "../../core/soundboard/CustomSample";
-import GuildConfigManager from "../../core/managers/GuildConfigManager";
-import SampleID from "../../core/soundboard/SampleID";
-import { search } from "../../core/soundboard/methods/searchMany";
-import { createDialog, DialogOptionsButton } from "../../util/builders/dialog";
+import { CustomSample } from "../../core/soundboard/CustomSample.js";
+import GuildConfigManager from "../../core/managers/GuildConfigManager.js";
+import SampleID from "../../core/soundboard/SampleID.js";
+import { search } from "../../core/soundboard/methods/searchMany.js";
+import { createDialog, DialogOptionsButton } from "../../util/builders/dialog.js";
 
 async function dialogSameId(interaction: Discord.CommandInteraction, sampleId: string) {
     await createDialog({

--- a/src/commands/soundboard/delete.ts
+++ b/src/commands/soundboard/delete.ts
@@ -6,12 +6,12 @@ import InteractionRegistry from "../../core/InteractionRegistry.js";
 import { CommandStringOption } from "../../modules/commands/CommandOption.js";
 import { TopCommand } from "../../modules/commands/TopCommand.js";
 import { EmbedType, replyEmbed, replyEmbedEphemeral } from "../../util/builders/embed.js";
+import { DialogOptionsButton, createDialog } from "../../util/builders/dialog.js";
 
 import { CustomSample } from "../../core/soundboard/CustomSample.js";
 import GuildConfigManager from "../../core/managers/GuildConfigManager.js";
 import SampleID from "../../core/soundboard/SampleID.js";
 import { search } from "../../core/soundboard/methods/searchMany.js";
-import { createDialog, DialogOptionsButton } from "../../util/builders/dialog.js";
 
 async function dialogSameId(interaction: Discord.CommandInteraction, sampleId: string) {
     await createDialog({

--- a/src/commands/soundboard/import.ts
+++ b/src/commands/soundboard/import.ts
@@ -1,16 +1,16 @@
 import Discord from "discord.js";
 
-import { BUTTON_TYPES, SAMPLE_TYPES } from "../../const";
+import { BUTTON_TYPES, SAMPLE_TYPES } from "../../const.js";
 
-import InteractionRegistry from "../../core/InteractionRegistry";
-import { CommandStringOption } from "../../modules/commands/CommandOption";
-import { createChoice } from "../../modules/commands/options/createChoice";
-import { TopCommand } from "../../modules/commands/TopCommand";
-import { EmbedType, replyEmbedEphemeral } from "../../util/builders/embed";
+import InteractionRegistry from "../../core/InteractionRegistry.js";
+import { CommandStringOption } from "../../modules/commands/CommandOption.js";
+import { createChoice } from "../../modules/commands/options/createChoice.js";
+import { TopCommand } from "../../modules/commands/TopCommand.js";
+import { EmbedType, replyEmbedEphemeral } from "../../util/builders/embed.js";
 
-import { CustomSample } from "../../core/soundboard/CustomSample";
-import GuildConfigManager from "../../core/managers/GuildConfigManager";
-import { UploadErrors } from "../../core/soundboard/methods/upload";
+import { CustomSample } from "../../core/soundboard/CustomSample.js";
+import GuildConfigManager from "../../core/managers/GuildConfigManager.js";
+import { UploadErrors } from "../../core/soundboard/methods/upload.js";
 
 async function importUser(interaction: Discord.ButtonInteraction | Discord.CommandInteraction, sample: CustomSample) {
     const user = interaction.user;

--- a/src/commands/soundboard/info.ts
+++ b/src/commands/soundboard/info.ts
@@ -1,16 +1,16 @@
 import Discord from "discord.js";
 
-import { EmbedType, replyEmbedEphemeral } from "../../util/builders/embed";
+import { EmbedType, replyEmbedEphemeral } from "../../util/builders/embed.js";
 
-import InteractionRegistry from "../../core/InteractionRegistry";
-import { CommandStringOption } from "../../modules/commands/CommandOption";
-import { TopCommand } from "../../modules/commands/TopCommand";
+import InteractionRegistry from "../../core/InteractionRegistry.js";
+import { CommandStringOption } from "../../modules/commands/CommandOption.js";
+import { TopCommand } from "../../modules/commands/TopCommand.js";
 
-import { CustomSample } from "../../core/soundboard/CustomSample";
-import GuildConfigManager from "../../core/managers/GuildConfigManager";
-import { search } from "../../core/soundboard/methods/searchMany";
-import { findOne } from "../../core/soundboard/methods/findOne";
-import { StandardSample } from "../../core/soundboard/StandardSample";
+import { CustomSample } from "../../core/soundboard/CustomSample.js";
+import GuildConfigManager from "../../core/managers/GuildConfigManager.js";
+import { search } from "../../core/soundboard/methods/searchMany.js";
+import { findOne } from "../../core/soundboard/methods/findOne.js";
+import { StandardSample } from "../../core/soundboard/StandardSample.js";
 
 async function canShowDelete(sample: CustomSample | StandardSample, userId: string, guild: Discord.Guild | null) {
     if (sample instanceof CustomSample) {

--- a/src/commands/soundboard/info.ts
+++ b/src/commands/soundboard/info.ts
@@ -1,10 +1,9 @@
 import Discord from "discord.js";
 
-import { EmbedType, replyEmbedEphemeral } from "../../util/builders/embed.js";
-
 import InteractionRegistry from "../../core/InteractionRegistry.js";
 import { CommandStringOption } from "../../modules/commands/CommandOption.js";
 import { TopCommand } from "../../modules/commands/TopCommand.js";
+import { EmbedType, replyEmbedEphemeral } from "../../util/builders/embed.js";
 
 import { CustomSample } from "../../core/soundboard/CustomSample.js";
 import GuildConfigManager from "../../core/managers/GuildConfigManager.js";

--- a/src/commands/soundboard/list.ts
+++ b/src/commands/soundboard/list.ts
@@ -4,12 +4,12 @@ import InteractionRegistry from "../../core/InteractionRegistry.js";
 import { TopCommand } from "../../modules/commands/TopCommand.js";
 import { CommandStringOption } from "../../modules/commands/CommandOption.js";
 import { createChoice } from "../../modules/commands/options/createChoice.js";
-import { createEmbed, EmbedType, replyEmbedEphemeral } from "../../util/builders/embed.js";
+import { EmbedType, createEmbed, replyEmbedEphemeral } from "../../util/builders/embed.js";
+import { SimpleFuncReturn } from "../../modules/commands/types/index.js";
 
 import { BUTTON_TYPES, SAMPLE_TYPES } from "../../const.js";
 import { CustomSample } from "../../core/soundboard/CustomSample.js";
 import { StandardSample } from "../../core/soundboard/StandardSample.js";
-import { SimpleFuncReturn } from "../../modules/commands/types/index.js";
 
 function generateSampleButtons(samples: CustomSample[] | StandardSample[]): Discord.MessageActionRow[] {
     const rows: Discord.MessageActionRow[] = [];

--- a/src/commands/soundboard/list.ts
+++ b/src/commands/soundboard/list.ts
@@ -1,15 +1,15 @@
 import Discord from "discord.js";
 
-import InteractionRegistry from "../../core/InteractionRegistry";
-import { TopCommand } from "../../modules/commands/TopCommand";
-import { CommandStringOption } from "../../modules/commands/CommandOption";
-import { createChoice } from "../../modules/commands/options/createChoice";
-import { createEmbed, EmbedType, replyEmbedEphemeral } from "../../util/builders/embed";
+import InteractionRegistry from "../../core/InteractionRegistry.js";
+import { TopCommand } from "../../modules/commands/TopCommand.js";
+import { CommandStringOption } from "../../modules/commands/CommandOption.js";
+import { createChoice } from "../../modules/commands/options/createChoice.js";
+import { createEmbed, EmbedType, replyEmbedEphemeral } from "../../util/builders/embed.js";
 
-import { BUTTON_TYPES, SAMPLE_TYPES } from "../../const";
-import { CustomSample } from "../../core/soundboard/CustomSample";
-import { StandardSample } from "../../core/soundboard/StandardSample";
-import { SimpleFuncReturn } from "../../modules/commands/types";
+import { BUTTON_TYPES, SAMPLE_TYPES } from "../../const.js";
+import { CustomSample } from "../../core/soundboard/CustomSample.js";
+import { StandardSample } from "../../core/soundboard/StandardSample.js";
+import { SimpleFuncReturn } from "../../modules/commands/types/index.js";
 
 function generateSampleButtons(samples: CustomSample[] | StandardSample[]): Discord.MessageActionRow[] {
     const rows: Discord.MessageActionRow[] = [];

--- a/src/commands/soundboard/play.ts
+++ b/src/commands/soundboard/play.ts
@@ -1,21 +1,21 @@
 import Discord from "discord.js";
 
-import { BUTTON_TYPES } from "../../const";
-import Logger from "../../log";
+import { BUTTON_TYPES } from "../../const.js";
+import Logger from "../../log.js";
 
-import { logErr } from "../../util/util";
-import { CmdInstallerArgs } from "../../util/types";
-import { EmbedType, replyEmbedEphemeral } from "../../util/builders/embed";
+import { logErr } from "../../util/util.js";
+import { CmdInstallerArgs } from "../../util/types.js";
+import { EmbedType, replyEmbedEphemeral } from "../../util/builders/embed.js";
 
-import { TopCommand } from "../../modules/commands/TopCommand";
-import { CommandStringOption } from "../../modules/commands/CommandOption";
+import { TopCommand } from "../../modules/commands/TopCommand.js";
+import { CommandStringOption } from "../../modules/commands/CommandOption.js";
 
-import AudioManager, { JoinFailureTypes } from "../../core/audio/AudioManager";
-import InteractionRegistry from "../../core/InteractionRegistry";
-import { CustomSample } from "../../core/soundboard/CustomSample";
-import { StandardSample } from "../../core/soundboard/StandardSample";
-import { search } from "../../core/soundboard/methods/searchMany";
-import { findOne } from "../../core/soundboard/methods/findOne";
+import AudioManager, { JoinFailureTypes } from "../../core/audio/AudioManager.js";
+import InteractionRegistry from "../../core/InteractionRegistry.js";
+import { CustomSample } from "../../core/soundboard/CustomSample.js";
+import { StandardSample } from "../../core/soundboard/StandardSample.js";
+import { search } from "../../core/soundboard/methods/searchMany.js";
+import { findOne } from "../../core/soundboard/methods/findOne.js";
 
 const log = Logger.child({ label: "Command => play" });
 

--- a/src/commands/soundboard/play.ts
+++ b/src/commands/soundboard/play.ts
@@ -2,16 +2,15 @@ import Discord from "discord.js";
 
 import { BUTTON_TYPES } from "../../const.js";
 import Logger from "../../log.js";
-
 import { logErr } from "../../util/util.js";
+
+import InteractionRegistry from "../../core/InteractionRegistry.js";
 import { CmdInstallerArgs } from "../../util/types.js";
 import { EmbedType, replyEmbedEphemeral } from "../../util/builders/embed.js";
-
 import { TopCommand } from "../../modules/commands/TopCommand.js";
 import { CommandStringOption } from "../../modules/commands/CommandOption.js";
 
 import AudioManager, { JoinFailureTypes } from "../../core/audio/AudioManager.js";
-import InteractionRegistry from "../../core/InteractionRegistry.js";
 import { CustomSample } from "../../core/soundboard/CustomSample.js";
 import { StandardSample } from "../../core/soundboard/StandardSample.js";
 import { search } from "../../core/soundboard/methods/searchMany.js";

--- a/src/commands/soundboard/upload.ts
+++ b/src/commands/soundboard/upload.ts
@@ -1,9 +1,9 @@
-import { SAMPLE_TYPES } from "../../const";
-import InteractionRegistry from "../../core/InteractionRegistry";
-import { TopCommand } from "../../modules/commands/TopCommand";
-import { CommandStringOption } from "../../modules/commands/CommandOption";
-import { createChoice } from "../../modules/commands/options/createChoice";
-import { upload } from "../../core/soundboard/methods/upload";
+import { SAMPLE_TYPES } from "../../const.js";
+import InteractionRegistry from "../../core/InteractionRegistry.js";
+import { TopCommand } from "../../modules/commands/TopCommand.js";
+import { CommandStringOption } from "../../modules/commands/CommandOption.js";
+import { createChoice } from "../../modules/commands/options/createChoice.js";
+import { upload } from "../../core/soundboard/methods/upload.js";
 
 InteractionRegistry.addCommand(new TopCommand({
     name: "upload",

--- a/src/commands/soundboard/upload.ts
+++ b/src/commands/soundboard/upload.ts
@@ -1,8 +1,10 @@
 import { SAMPLE_TYPES } from "../../const.js";
+
 import InteractionRegistry from "../../core/InteractionRegistry.js";
 import { TopCommand } from "../../modules/commands/TopCommand.js";
 import { CommandStringOption } from "../../modules/commands/CommandOption.js";
 import { createChoice } from "../../modules/commands/options/createChoice.js";
+
 import { upload } from "../../core/soundboard/methods/upload.js";
 
 InteractionRegistry.addCommand(new TopCommand({

--- a/src/commands/vote.ts
+++ b/src/commands/vote.ts
@@ -1,15 +1,15 @@
 import { userMention } from "@discordjs/builders";
 import Discord from "discord.js";
 
-import { SAMPLE_TYPES } from "../const";
-import { BOT_NAME, TOP_GG_WEBHOOK_TOKEN } from "../config";
-import InteractionRegistry from "../core/InteractionRegistry";
-import { CustomSample } from "../core/soundboard/CustomSample";
-import { TopCommand } from "../modules/commands/TopCommand";
-import { SingleSoundboardSlot } from "../modules/database/schemas/SoundboardSlotsSchema";
-import { CmdInstallerArgs } from "../util/types";
-import { createEmbed, replyEmbed } from "../util/builders/embed";
-import * as models from "../modules/database/models";
+import { SAMPLE_TYPES } from "../const.js";
+import { BOT_NAME, TOP_GG_WEBHOOK_TOKEN } from "../config.js";
+import InteractionRegistry from "../core/InteractionRegistry.js";
+import { CustomSample } from "../core/soundboard/CustomSample.js";
+import { TopCommand } from "../modules/commands/TopCommand.js";
+import { SingleSoundboardSlot } from "../modules/database/schemas/SoundboardSlotsSchema.js";
+import { CmdInstallerArgs } from "../util/types.js";
+import { createEmbed, replyEmbed } from "../util/builders/embed.js";
+import * as models from "../modules/database/models.js";
 
 if (TOP_GG_WEBHOOK_TOKEN) {
     InteractionRegistry.addCommand(new TopCommand({

--- a/src/commands/vote.ts
+++ b/src/commands/vote.ts
@@ -13,6 +13,16 @@ import { createEmbed, replyEmbed } from "../util/builders/embed.js";
 import { SingleSoundboardSlot } from "../modules/database/schemas/SoundboardSlotsSchema.js";
 import * as models from "../modules/database/models.js";
 
+// label text max 80 characters
+
+const formatEllipsis = (base: string, insert: string, length: number) => {
+    const leftover_length = length - base.length + 1;
+    if (insert.length > leftover_length) {
+        insert = insert.slice(0, Math.max(0, leftover_length - 3)) + "...";
+    }
+    return base.replace("%", insert);
+};
+
 if (TOP_GG_WEBHOOK_TOKEN) {
     InteractionRegistry.addCommand(new TopCommand({
         name: "vote",
@@ -34,16 +44,6 @@ if (TOP_GG_WEBHOOK_TOKEN) {
                     "One vote equals one slot. On weekends you get two slots! " +
                     `A soundboard can't have more than ${CustomSample.MAX_SLOTS} slots (at the moment).`,
                 );
-
-            // label text max 80 characters
-
-            const formatEllipsis = (base: string, insert: string, length: number) => {
-                const leftover_length = length - base.length + 1;
-                if (insert.length > leftover_length) {
-                    insert = insert.substring(0, leftover_length - 3) + "...";
-                }
-                return base.replace("%", insert);
-            };
 
             const user = interaction.user;
             const user_vote_link = vote_base_link + "&userId=" + user.id;
@@ -142,13 +142,13 @@ export function install({ client }: CmdInstallerArgs): void {
         if (slot.ref) {
             try {
                 await sendMessageReply(client, slot, new_slots, slot.ref);
-            } catch (_) { _; }
+            } catch (error) { error; }
         }
 
         if (slot.slotType === SAMPLE_TYPES.USER) {
             try {
                 await sendDM(client, slot, new_slots);
-            } catch (_) { _; }
+            } catch (error) { error; }
         }
     });
 }

--- a/src/commands/vote.ts
+++ b/src/commands/vote.ts
@@ -3,12 +3,14 @@ import Discord from "discord.js";
 
 import { SAMPLE_TYPES } from "../const.js";
 import { BOT_NAME, TOP_GG_WEBHOOK_TOKEN } from "../config.js";
+
 import InteractionRegistry from "../core/InteractionRegistry.js";
 import { CustomSample } from "../core/soundboard/CustomSample.js";
 import { TopCommand } from "../modules/commands/TopCommand.js";
-import { SingleSoundboardSlot } from "../modules/database/schemas/SoundboardSlotsSchema.js";
 import { CmdInstallerArgs } from "../util/types.js";
 import { createEmbed, replyEmbed } from "../util/builders/embed.js";
+
+import { SingleSoundboardSlot } from "../modules/database/schemas/SoundboardSlotsSchema.js";
 import * as models from "../modules/database/models.js";
 
 if (TOP_GG_WEBHOOK_TOKEN) {

--- a/src/config.ts
+++ b/src/config.ts
@@ -2,6 +2,7 @@ import path from "node:path";
 import dotenv from "dotenv";
 import fs from "fs-extra";
 import { PackageJson } from "type-fest";
+
 import { getDirname } from "./util/esm.js";
 
 dotenv.config();

--- a/src/config.ts
+++ b/src/config.ts
@@ -2,6 +2,7 @@ import path from "node:path";
 import dotenv from "dotenv";
 import fs from "fs-extra";
 import { PackageJson } from "type-fest";
+import { getDirname } from "./util/esm.js";
 
 dotenv.config();
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -51,17 +51,20 @@ export const TOP_GG_WEBHOOK_TOKEN = process.env.SOUNDBORT_TOP_GG_WEBHOOK_TOKEN;
 
 // ////////////// INFO //////////////
 
-const package_file: PackageJson = JSON.parse(fs.readFileSync(path.resolve(__dirname, "..", "package.json"), "utf8"));
+const dirname = getDirname(import.meta.url);
+
+export const PROJECT_ROOT = path.normalize(path.resolve(dirname, ".."));
+export const ASSETS_DIR = path.resolve(PROJECT_ROOT, "assets");
+export const DATA_DIR = path.resolve(PROJECT_ROOT, "data");
+export const LOGS_DIR = path.resolve(PROJECT_ROOT, "logs");
+
+const package_file: PackageJson = JSON.parse(fs.readFileSync(path.resolve(PROJECT_ROOT, "package.json"), "utf8"));
 
 export const VERSION = package_file.version as string + (
     ENVIRONMENT !== EnvironmentStages.PROD
         ? `-${ENVIRONMENT.toLowerCase()}`
         : ""
 );
-
-export const PROJECT_ROOT = path.resolve(__dirname, "..");
-
-export const DATA_BASE_PATH = path.resolve(PROJECT_ROOT, "data");
 
 export const METRICS_PORT = 6969;
 export const WEBHOOK_PORT = 8080;

--- a/src/const.ts
+++ b/src/const.ts
@@ -1,14 +1,14 @@
 export enum COLOR {
     // TEXT: 0x2f3136,
     // WHITE: 0xffffff,
-    CHART_FG = 0xffffff,
-    CHART_BG = 0x2f3136,
+    CHART_FG = 0xFF_FF_FF,
+    CHART_BG = 0x2F_31_36,
 
-    PRIMARY = 0x6378CA,
-    INFO = 0xADBCE6,
-    SUCCESS = 0x62D945,
-    WARNING = 0xe6a23c,
-    ERROR = 0xd8315b,
+    PRIMARY = 0x63_78_CA,
+    INFO = 0xAD_BC_E6,
+    SUCCESS = 0x62_D9_45,
+    WARNING = 0xE6_A2_3C,
+    ERROR = 0xD8_31_5B,
 }
 
 export enum EMOJI {

--- a/src/core/Core.ts
+++ b/src/core/Core.ts
@@ -2,16 +2,17 @@ import Discord from "discord.js";
 import path from "node:path";
 import topGGStatsPoster from "topgg-autoposter";
 
-import Logger from "../log";
-import { logErr } from "../util/util";
-import { TOP_GG_TOKEN, TOP_GG_WEBHOOK_TOKEN } from "../config";
+import Logger from "../log.js";
+import { logErr } from "../util/util.js";
+import { getDirname } from "../util/esm.js";
+import { TOP_GG_TOKEN, TOP_GG_WEBHOOK_TOKEN } from "../config.js";
 
-import StatsCollectorManager from "./managers/StatsCollectorManager";
-import WebhookManager from "./managers/WebhookManager";
-import onInteractionCreate from "./events/onInteractionCreate";
-import onVoiceStateUpdate from "./events/onVoiceStateUpdate";
+import StatsCollectorManager from "./managers/StatsCollectorManager.js";
+import WebhookManager from "./managers/WebhookManager.js";
+import onInteractionCreate from "./events/onInteractionCreate.js";
+import onVoiceStateUpdate from "./events/onVoiceStateUpdate.js";
 
-import * as InteractionLoader from "./InteractionLoader";
+import * as InteractionLoader from "./InteractionLoader.js";
 
 const log = Logger.child({ label: "Core" });
 

--- a/src/core/Core.ts
+++ b/src/core/Core.ts
@@ -1,10 +1,8 @@
 import Discord from "discord.js";
-import path from "node:path";
 import topGGStatsPoster from "topgg-autoposter";
 
 import Logger from "../log.js";
 import { logErr } from "../util/util.js";
-import { getDirname } from "../util/esm.js";
 import { TOP_GG_TOKEN, TOP_GG_WEBHOOK_TOKEN } from "../config.js";
 
 import StatsCollectorManager from "./managers/StatsCollectorManager.js";
@@ -40,9 +38,7 @@ export default class Core {
 
         // ///////////////////////
 
-        const commands_path = path.join(__dirname, "..", "commands");
-
-        await InteractionLoader.loadCommands(this.client, this.stats_collector, commands_path);
+        await InteractionLoader.loadCommands(this.client, this.stats_collector);
 
         await InteractionLoader.deployCommands(this.client);
 

--- a/src/core/InteractionLoader.ts
+++ b/src/core/InteractionLoader.ts
@@ -1,15 +1,16 @@
 import Discord from "discord.js";
-import path from "path";
+import path from "node:path";
 
-import nanoTimer from "../util/timer";
-import Logger from "../log";
-import { walk } from "../util/files";
-import { CmdInstallerArgs, CmdInstallerFile } from "../util/types";
-import { logErr } from "../util/util";
+import nanoTimer from "../util/timer.js";
+import Logger from "../log.js";
+import { walk } from "../util/files.js";
+import { CmdInstallerArgs, CmdInstallerFile } from "../util/types.js";
+import { logErr } from "../util/util.js";
 
-import InteractionRegistry from "./InteractionRegistry";
-import GuildConfigManager from "./managers/GuildConfigManager";
-import StatsCollectorManager from "./managers/StatsCollectorManager";
+import InteractionRegistry from "./InteractionRegistry.js";
+import GuildConfigManager from "./managers/GuildConfigManager.js";
+import StatsCollectorManager from "./managers/StatsCollectorManager.js";
+import { getDirname } from "../util/esm.js";
 
 const log = Logger.child({ label: "Core => InteractionLoader" });
 

--- a/src/core/InteractionRegistry.ts
+++ b/src/core/InteractionRegistry.ts
@@ -1,10 +1,10 @@
 import Discord from "discord.js";
 import qs from "query-string";
 
-import { BUTTON_TYPES } from "../const";
-import { TopCommand } from "../modules/commands/TopCommand";
-import { TopCommandGroup } from "../modules/commands/TopCommandGroup";
-import { SimpleFuncReturn } from "../modules/commands/types";
+import { BUTTON_TYPES } from "../const.js";
+import { TopCommand } from "../modules/commands/TopCommand.js";
+import { TopCommandGroup } from "../modules/commands/TopCommandGroup.js";
+import { SimpleFuncReturn } from "../modules/commands/types/index.js";
 
 export type ButtonFilter = Record<string, string>;
 export type ButtonParsed = qs.ParsedQuery<string> & { t: BUTTON_TYPES };

--- a/src/core/audio/AudioManager.ts
+++ b/src/core/audio/AudioManager.ts
@@ -1,10 +1,10 @@
 import Discord from "discord.js";
 import * as Voice from "@discordjs/voice";
 
-import Logger from "../../log";
-import { logErr } from "../../util/util";
-import { GenericListener, TypedEventEmitter } from "../../util/emitter";
-import { AudioSubscription } from "./AudioSubscription";
+import Logger from "../../log.js";
+import { logErr } from "../../util/util.js";
+import { GenericListener, TypedEventEmitter } from "../../util/emitter.js";
+import { AudioSubscription } from "./AudioSubscription.js";
 
 const log = Logger.child({ label: "Audio" });
 

--- a/src/core/audio/AudioSubscription.ts
+++ b/src/core/audio/AudioSubscription.ts
@@ -1,4 +1,5 @@
 import * as Voice from "@discordjs/voice";
+
 import Logger from "../../log.js";
 import { timeout } from "../../util/promises.js";
 import { logErr } from "../../util/util.js";

--- a/src/core/audio/AudioSubscription.ts
+++ b/src/core/audio/AudioSubscription.ts
@@ -33,7 +33,7 @@ export class AudioSubscription {
                     the voice connection.
 					*/
                     try {
-                        await Voice.entersState(this.voice_connection, Voice.VoiceConnectionStatus.Connecting, 5_000);
+                        await Voice.entersState(this.voice_connection, Voice.VoiceConnectionStatus.Connecting, 5000);
                         // Probably moved voice channel
                     } catch {
                         this.voice_connection.destroy(); // destroy event will bubble up to execute this.stop()
@@ -43,7 +43,7 @@ export class AudioSubscription {
                     /*
                     The disconnect in this case is recoverable, and we also have <5 repeated attempts so we will reconnect.
 					*/
-                    await timeout((this.voice_connection.rejoinAttempts + 1) * 5_000);
+                    await timeout((this.voice_connection.rejoinAttempts + 1) * 5000);
                     this.voice_connection.rejoin();
                 } else {
                     /*

--- a/src/core/audio/AudioSubscription.ts
+++ b/src/core/audio/AudioSubscription.ts
@@ -1,7 +1,7 @@
 import * as Voice from "@discordjs/voice";
-import Logger from "../../log";
-import { timeout } from "../../util/promises";
-import { logErr } from "../../util/util";
+import Logger from "../../log.js";
+import { timeout } from "../../util/promises.js";
+import { logErr } from "../../util/util.js";
 
 const log = Logger.child({ label: "Audio => AudioSubscription" });
 

--- a/src/core/events/onInteractionCreate.ts
+++ b/src/core/events/onInteractionCreate.ts
@@ -1,13 +1,13 @@
 import Discord from "discord.js";
 
-import Logger from "../../log";
-import { BUTTON_TYPES } from "../../const";
-import { logErr } from "../../util/util";
-import * as models from "../../modules/database/models";
+import Logger from "../../log.js";
+import { BUTTON_TYPES } from "../../const.js";
+import { logErr } from "../../util/util.js";
+import * as models from "../../modules/database/models.js";
 
-import InteractionRegistry from "../InteractionRegistry";
-import StatsCollectorManager from "../managers/StatsCollectorManager";
-import { EmbedType, replyEmbedEphemeral } from "../../util/builders/embed";
+import InteractionRegistry from "../InteractionRegistry.js";
+import StatsCollectorManager from "../managers/StatsCollectorManager.js";
+import { EmbedType, replyEmbedEphemeral } from "../../util/builders/embed.js";
 
 const log = Logger.child({ label: "Core => onInteractionCreate" });
 

--- a/src/core/events/onInteractionCreate.ts
+++ b/src/core/events/onInteractionCreate.ts
@@ -63,11 +63,11 @@ export default function onInteractionCreate(stats_collector: StatsCollectorManag
             // remove this by, like, September 1st to 8th
             if (customId.startsWith("sample.custom.")) {
                 decoded.t = BUTTON_TYPES.PLAY_CUSTOM;
-                decoded.id = customId.substring("sample.custom.".length);
+                decoded.id = customId.slice("sample.custom.".length);
             }
             if (customId.startsWith("sample.predef.")) {
                 decoded.t = BUTTON_TYPES.PLAY_STANDA;
-                decoded.n = customId.substring("sample.predef.".length);
+                decoded.n = customId.slice("sample.predef.".length);
             }
 
             for (const button_handler of InteractionRegistry.buttons) {

--- a/src/core/events/onVoiceStateUpdate.ts
+++ b/src/core/events/onVoiceStateUpdate.ts
@@ -1,6 +1,6 @@
 import Discord from "discord.js";
 
-import AudioManager from "../audio/AudioManager";
+import AudioManager from "../audio/AudioManager.js";
 
 export default function onVoiceStateUpdate() {
     return (old_state: Discord.VoiceState, new_state: Discord.VoiceState): void => {

--- a/src/core/managers/GuildConfigManager.ts
+++ b/src/core/managers/GuildConfigManager.ts
@@ -1,8 +1,8 @@
 import Discord from "discord.js";
-import { fetchMember, guessModRole } from "../../util/util";
-import * as models from "../../modules/database/models";
-import { ConfigSchema } from "../../modules/database/schemas/ConfigSchema";
-import { GenericListener, TypedEventEmitter } from "../../util/emitter";
+import { fetchMember, guessModRole } from "../../util/util.js";
+import * as models from "../../modules/database/models.js";
+import { ConfigSchema } from "../../modules/database/schemas/ConfigSchema.js";
+import { GenericListener, TypedEventEmitter } from "../../util/emitter.js";
 
 // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 type EventMap = {

--- a/src/core/managers/GuildConfigManager.ts
+++ b/src/core/managers/GuildConfigManager.ts
@@ -1,8 +1,9 @@
 import Discord from "discord.js";
+
 import { fetchMember, guessModRole } from "../../util/util.js";
+import { GenericListener, TypedEventEmitter } from "../../util/emitter.js";
 import * as models from "../../modules/database/models.js";
 import { ConfigSchema } from "../../modules/database/schemas/ConfigSchema.js";
-import { GenericListener, TypedEventEmitter } from "../../util/emitter.js";
 
 // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 type EventMap = {

--- a/src/core/managers/StatsCollectorManager.ts
+++ b/src/core/managers/StatsCollectorManager.ts
@@ -5,15 +5,15 @@ import http from "node:http";
 import os from "node:os";
 import { promisify } from "node:util";
 
-import * as database from "../../modules/database";
-import { StatsSchema } from "../../modules/database/schemas/StatsSchema";
-import Logger from "../../log";
-import { CustomSample } from "../soundboard/CustomSample";
-import * as models from "../../modules/database/models";
-import { METRICS_PORT } from "../../config";
-import { logErr } from "../../util/util";
-import { lastItem } from "../../util/array";
-import { onExit } from "../../util/exit";
+import * as database from "../../modules/database/index.js";
+import { StatsSchema } from "../../modules/database/schemas/StatsSchema.js";
+import Logger from "../../log.js";
+import { CustomSample } from "../soundboard/CustomSample.js";
+import * as models from "../../modules/database/models.js";
+import { METRICS_PORT } from "../../config.js";
+import { logErr } from "../../util/util.js";
+import { lastItem } from "../../util/array.js";
+import { onExit } from "../../util/exit.js";
 
 const log = Logger.child({ label: "Core => StatsCollectorManager" });
 

--- a/src/core/managers/StatsCollectorManager.ts
+++ b/src/core/managers/StatsCollectorManager.ts
@@ -87,7 +87,7 @@ export default class StatsCollectorManager extends EventEmitter {
         const uptime = process.uptime();
 
         const cpu_load_avg = os.loadavg() as [number, number, number];
-        const memory_usage = 1.0 - (os.freemem() / os.totalmem());
+        const memory_usage = 1 - (os.freemem() / os.totalmem());
 
         const db_stats = await database.get().stats();
 

--- a/src/core/managers/WebhookManager.ts
+++ b/src/core/managers/WebhookManager.ts
@@ -7,7 +7,7 @@ import { TOP_GG_WEBHOOK_TOKEN, WEBHOOK_PORT } from "../../config.js";
 import Logger from "../../log.js";
 import { logErr } from "../../util/util.js";
 import * as models from "../../modules/database/models.js";
-import { TypedEventEmitter, GenericListener } from "../../util/emitter.js";
+import { GenericListener, TypedEventEmitter } from "../../util/emitter.js";
 import { VotesSchema } from "../../modules/database/schemas/VotesSchema.js";
 import { onExit } from "../../util/exit.js";
 

--- a/src/core/managers/WebhookManager.ts
+++ b/src/core/managers/WebhookManager.ts
@@ -3,13 +3,13 @@ import express from "express";
 import http from "node:http";
 import { promisify } from "node:util";
 
-import { TOP_GG_WEBHOOK_TOKEN, WEBHOOK_PORT } from "../../config";
-import Logger from "../../log";
-import { logErr } from "../../util/util";
-import * as models from "../../modules/database/models";
-import { TypedEventEmitter, GenericListener } from "../../util/emitter";
-import { VotesSchema } from "../../modules/database/schemas/VotesSchema";
-import { onExit } from "../../util/exit";
+import { TOP_GG_WEBHOOK_TOKEN, WEBHOOK_PORT } from "../../config.js";
+import Logger from "../../log.js";
+import { logErr } from "../../util/util.js";
+import * as models from "../../modules/database/models.js";
+import { TypedEventEmitter, GenericListener } from "../../util/emitter.js";
+import { VotesSchema } from "../../modules/database/schemas/VotesSchema.js";
+import { onExit } from "../../util/exit.js";
 
 const log = Logger.child({ label: "Core => WebhookManager" });
 

--- a/src/core/soundboard/AbstractSample.ts
+++ b/src/core/soundboard/AbstractSample.ts
@@ -3,11 +3,11 @@ import path from "node:path";
 import * as Voice from "@discordjs/voice";
 import Discord from "discord.js";
 
-import { DATA_BASE_PATH } from "../../config.js";
+import { DATA_DIR } from "../../config.js";
 import { SoundboardStandardSampleSchema } from "../../modules/database/schemas/SoundboardStandardSampleSchema.js";
 import { EmbedType } from "../../util/builders/embed.js";
 
-const BASE = path.join(DATA_BASE_PATH, "soundboard");
+const BASE = path.join(DATA_DIR, "soundboard");
 fs.mkdirpSync(BASE);
 
 export interface ToEmbedOptions {

--- a/src/core/soundboard/AbstractSample.ts
+++ b/src/core/soundboard/AbstractSample.ts
@@ -3,9 +3,9 @@ import path from "node:path";
 import * as Voice from "@discordjs/voice";
 import Discord from "discord.js";
 
-import { DATA_BASE_PATH } from "../../config";
-import { SoundboardStandardSampleSchema } from "../../modules/database/schemas/SoundboardStandardSampleSchema";
-import { EmbedType } from "../../util/builders/embed";
+import { DATA_BASE_PATH } from "../../config.js";
+import { SoundboardStandardSampleSchema } from "../../modules/database/schemas/SoundboardStandardSampleSchema.js";
+import { EmbedType } from "../../util/builders/embed.js";
 
 const BASE = path.join(DATA_BASE_PATH, "soundboard");
 fs.mkdirpSync(BASE);

--- a/src/core/soundboard/CustomSample.ts
+++ b/src/core/soundboard/CustomSample.ts
@@ -67,10 +67,10 @@ export class CustomSample extends AbstractSample implements SoundboardCustomSamp
     }
 
     isInUsers(userId: Discord.Snowflake): boolean {
-        return this.userIds.some(id => id === userId);
+        return this.userIds.includes(userId);
     }
     isInGuilds(guildId: Discord.Snowflake): boolean {
-        return this.guildIds.some(id => id === guildId);
+        return this.guildIds.includes(guildId);
     }
 
     isCreator(user_guild_id: Discord.Snowflake): boolean {
@@ -183,20 +183,16 @@ export class CustomSample extends AbstractSample implements SoundboardCustomSamp
                 $options: "i",
             };
 
-            if (guildId) {
-                query = {
-                    $or: [
-                        { userIds: userId },
-                        { guildIds: guildId },
-                    ],
-                    name: name_query,
-                };
-            } else {
-                query = {
-                    userId,
-                    name: name_query,
-                };
-            }
+            query = guildId ? {
+                $or: [
+                    { userIds: userId },
+                    { guildIds: guildId },
+                ],
+                name: name_query,
+            } : {
+                userId,
+                name: name_query,
+            };
         }
 
         const docs = await models.custom_sample.findMany(query);

--- a/src/core/soundboard/CustomSample.ts
+++ b/src/core/soundboard/CustomSample.ts
@@ -6,21 +6,21 @@ import moment from "moment";
 import { Filter } from "mongodb";
 import escapeStringRegexp from "escape-string-regexp";
 
-import Logger from "../../log";
-import { BUTTON_TYPES, SAMPLE_TYPES } from "../../const";
-import { logErr } from "../../util/util";
-import { createEmbed } from "../../util/builders/embed";
-import { GenericListener, TypedEventEmitter } from "../../util/emitter";
+import Logger from "../../log.js";
+import { BUTTON_TYPES, SAMPLE_TYPES } from "../../const.js";
+import { logErr } from "../../util/util.js";
+import { createEmbed } from "../../util/builders/embed.js";
+import { GenericListener, TypedEventEmitter } from "../../util/emitter.js";
 
-import { AbstractSample, ToEmbedOptions } from "./AbstractSample";
+import { AbstractSample, ToEmbedOptions } from "./AbstractSample.js";
 
-import * as models from "../../modules/database/models";
-import { SoundboardCustomSampleSchema, SoundboardCustomSampleScope } from "../../modules/database/schemas/SoundboardCustomSampleSchema";
-import { SingleSoundboardSlot, SoundboardSlot } from "../../modules/database/schemas/SoundboardSlotsSchema";
-import { VotesSchema } from "../../modules/database/schemas/VotesSchema";
+import * as models from "../../modules/database/models.js";
+import { SoundboardCustomSampleSchema, SoundboardCustomSampleScope } from "../../modules/database/schemas/SoundboardCustomSampleSchema.js";
+import { SingleSoundboardSlot, SoundboardSlot } from "../../modules/database/schemas/SoundboardSlotsSchema.js";
+import { VotesSchema } from "../../modules/database/schemas/VotesSchema.js";
 
-import InteractionRegistry from "../InteractionRegistry";
-import WebhookManager from "../managers/WebhookManager";
+import InteractionRegistry from "../InteractionRegistry.js";
+import WebhookManager from "../managers/WebhookManager.js";
 
 const log = Logger.child({ label: "SampleManager => CustomSample" });
 

--- a/src/core/soundboard/SampleID.ts
+++ b/src/core/soundboard/SampleID.ts
@@ -1,22 +1,30 @@
 import { customAlphabet } from "nanoid";
 
-export default class SampleID {
-    /**
-     * Checks if a string is a valid SampleID string
-     * @param {string} id
-     * @returns {boolean}
-     */
-    static isId(id: string): boolean {
-        return SampleID.REGEX.test(id);
-    }
+const PREFIX = "s";
+const CHARSET = "0123456789abcdefghijklmnopqrstuvwxyz";
+const LENGTH = 6;
+const REGEX = new RegExp(`^${PREFIX}[${CHARSET}]{${LENGTH}}$`);
+const nanoid = customAlphabet(CHARSET, LENGTH);
 
-    static generate(): string {
-        return SampleID.PREFIX + SampleID.nanoid();
-    }
-
-    static PREFIX = "s";
-    static CHARSET = "0123456789abcdefghijklmnopqrstuvwxyz";
-    static LENGTH = 6;
-    static REGEX = new RegExp(`^${SampleID.PREFIX}[${SampleID.CHARSET}]{${SampleID.LENGTH}}$`);
-    static nanoid = customAlphabet(SampleID.CHARSET, SampleID.LENGTH);
+/**
+ * Checks if a string is a valid SampleID string
+ * @param {string} id
+ * @returns {boolean}
+ */
+function isId(id: string): boolean {
+    return REGEX.test(id);
 }
+
+function generate(): string {
+    return PREFIX + nanoid();
+}
+
+export default {
+    PREFIX,
+    CHARSET,
+    LENGTH,
+    REGEX,
+    nanoid,
+    isId,
+    generate,
+};

--- a/src/core/soundboard/StandardSample.ts
+++ b/src/core/soundboard/StandardSample.ts
@@ -5,14 +5,14 @@ import Discord from "discord.js";
 import moment from "moment";
 import escapeStringRegexp from "escape-string-regexp";
 
-import InteractionRegistry from "../InteractionRegistry";
-import { createEmbed } from "../../util/builders/embed";
+import InteractionRegistry from "../InteractionRegistry.js";
+import { createEmbed } from "../../util/builders/embed.js";
 
-import { BUTTON_TYPES } from "../../const";
-import Logger from "../../log";
-import * as models from "../../modules/database/models";
-import { SoundboardStandardSampleSchema } from "../../modules/database/schemas/SoundboardStandardSampleSchema";
-import { AbstractSample, ToEmbedOptions } from "./AbstractSample";
+import { BUTTON_TYPES } from "../../const.js";
+import Logger from "../../log.js";
+import * as models from "../../modules/database/models.js";
+import { SoundboardStandardSampleSchema } from "../../modules/database/schemas/SoundboardStandardSampleSchema.js";
+import { AbstractSample, ToEmbedOptions } from "./AbstractSample.js";
 
 const log = Logger.child({ label: "SampleManager => StandardSample" });
 

--- a/src/core/soundboard/methods/findOne.ts
+++ b/src/core/soundboard/methods/findOne.ts
@@ -24,7 +24,7 @@ export async function findOne(
         // custom samples with the same name => making sure it's being played what was selected
         if (!sample) {
             if (name.startsWith(STANDARD_SAMPLE_PREFIX)) {
-                sample = await StandardSample.findByName(name.substr(STANDARD_SAMPLE_PREFIX.length));
+                sample = await StandardSample.findByName(name.slice(STANDARD_SAMPLE_PREFIX.length));
             } else {
                 sample = await CustomSample.findByName(guildId ?? null, userId, name) ||
                         await StandardSample.findByName(name);

--- a/src/core/soundboard/methods/findOne.ts
+++ b/src/core/soundboard/methods/findOne.ts
@@ -1,9 +1,9 @@
 import Discord from "discord.js";
 
-import { SAMPLE_TYPES } from "../../../const";
-import SampleID from "../SampleID";
-import { CustomSample } from "../CustomSample";
-import { StandardSample } from "../StandardSample";
+import { SAMPLE_TYPES } from "../../../const.js";
+import SampleID from "../SampleID.js";
+import { CustomSample } from "../CustomSample.js";
+import { StandardSample } from "../StandardSample.js";
 
 export const STANDARD_SAMPLE_PREFIX = "%";
 

--- a/src/core/soundboard/methods/searchMany.ts
+++ b/src/core/soundboard/methods/searchMany.ts
@@ -1,9 +1,9 @@
 import Discord from "discord.js";
 
-import GuildConfigManager from "../../managers/GuildConfigManager";
-import { CustomSample } from "../CustomSample";
-import { StandardSample } from "../StandardSample";
-import { STANDARD_SAMPLE_PREFIX } from "./findOne";
+import GuildConfigManager from "../../managers/GuildConfigManager.js";
+import { CustomSample } from "../CustomSample.js";
+import { StandardSample } from "../StandardSample.js";
+import { STANDARD_SAMPLE_PREFIX } from "./findOne.js";
 
 function compareName(a: { name: string }, b: { name: string }) {
     if (a.name < b.name) {

--- a/src/core/soundboard/methods/upload.ts
+++ b/src/core/soundboard/methods/upload.ts
@@ -24,7 +24,7 @@ const log = Logger.child({ label: "Sample => Uploader" });
 
 export const MAX_LEN_NAME = 30;
 export const MAX_SIZE = 4;
-export const MAX_DURATION = 30 * 1_000;
+export const MAX_DURATION = 30 * 1000;
 
 export const UploadErrors = {
     OutOfSpace: "Disk space is running out. Please inform the developer.",
@@ -56,7 +56,7 @@ function convertAudio(input: string, output: string): Promise<void> {
             .audioFilter("silenceremove=1:0:-50dB")
             .audioCodec("libopus")
             .audioBitrate("96k")
-            .audioFrequency(48000)
+            .audioFrequency(48_000)
             .audioChannels(2)
             .addOutputOption("-map 0:a:0") // only first input audio stream
             .addOutputOption("-map_metadata -1") // strip all metadata from input
@@ -169,7 +169,7 @@ async function _upload(interaction: Discord.CommandInteraction, name: string, sc
         return await failed(UploadErrors.NameOutOfRange);
     }
 
-    if (!/^[a-zA-Z0-9 .,_-]*$/.test(name)) {
+    if (!/^[\w ,.-]*$/.test(name)) {
         return await failed(UploadErrors.InvalidName);
     }
 

--- a/src/core/soundboard/methods/upload.ts
+++ b/src/core/soundboard/methods/upload.ts
@@ -7,16 +7,16 @@ import fs from "fs-extra";
 import Discord from "discord.js";
 import ffmpeg, { FfprobeData } from "fluent-ffmpeg";
 
-import { SAMPLE_TYPES } from "../../../const";
-import Logger from "../../../log";
-import { downloadFile, isEnoughDiskSpace } from "../../../util/files";
+import { SAMPLE_TYPES } from "../../../const.js";
+import Logger from "../../../log.js";
+import { downloadFile, isEnoughDiskSpace } from "../../../util/files.js";
 
-import SampleID from "../SampleID";
-import { CustomSample } from "../CustomSample";
-import { StandardSample } from "../StandardSample";
-import { isOwner, logErr } from "../../../util/util";
-import { EmbedType, replyEmbed } from "../../../util/builders/embed";
-import GuildConfigManager from "../../managers/GuildConfigManager";
+import SampleID from "../SampleID.js";
+import { CustomSample } from "../CustomSample.js";
+import { StandardSample } from "../StandardSample.js";
+import { isOwner, logErr } from "../../../util/util.js";
+import { EmbedType, replyEmbed } from "../../../util/builders/embed.js";
+import GuildConfigManager from "../../managers/GuildConfigManager.js";
 
 const ffprobe = promisify(ffmpeg.ffprobe) as (file: string) => Promise<FfprobeData>;
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -97,21 +97,18 @@ client.on("shardError", (error, shard_id) => { djs_log.error(`ID:${shard_id}`, {
 
 // ////////////// Initialize Bot //////////////
 
-Promise.resolve()
-    .then(async () => {
-        await database.connect();
+try {
+    await database.connect();
 
-        const ready_promise = new Promise<Discord.Client<true>>(resolve => client.once("ready", resolve));
+    const ready_promise = new Promise<Discord.Client<true>>(resolve => client.once("ready", resolve));
 
-        djs_log.info("Logging in...");
-        await client.login(DISCORD_TOKEN);
-        djs_log.info("Login success");
+    djs_log.info("Logging in...");
+    await client.login(DISCORD_TOKEN);
+    djs_log.info("Login success");
 
-        return await ready_promise;
-    })
-    .then(client => Core.create(client))
-    .catch(error => {
-        console.error(error);
-        log.error({ error: logErr(error), message: "Failed to log in" });
-        exit(1);
-    });
+    await Core.create(await ready_promise);
+} catch (error) {
+    console.error(error);
+    log.error({ error: logErr(error), message: "Failed to log in" });
+    exit(1);
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,13 +1,13 @@
-import "./util/banner_printer";
+import "./util/banner_printer.js";
 
 import Discord from "discord.js";
 
-import Logger from "./log";
-import { DISCORD_TOKEN } from "./config";
-import { exit, onExit } from "./util/exit";
-import Core from "./core/Core";
-import * as database from "./modules/database/index";
-import { logErr } from "./util/util";
+import Logger from "./log.js";
+import { DISCORD_TOKEN } from "./config.js";
+import { exit, onExit } from "./util/exit.js";
+import Core from "./core/Core.js";
+import * as database from "./modules/database/index.js";
+import { logErr } from "./util/util.js";
 
 const log = Logger.child({ label: "Index" });
 const djs_log = Logger.child({ label: "discord.js" });

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,9 +5,9 @@ import Discord from "discord.js";
 import Logger from "./log.js";
 import { DISCORD_TOKEN } from "./config.js";
 import { exit, onExit } from "./util/exit.js";
+import { logErr } from "./util/util.js";
 import Core from "./core/Core.js";
 import * as database from "./modules/database/index.js";
-import { logErr } from "./util/util.js";
 
 const log = Logger.child({ label: "Index" });
 const djs_log = Logger.child({ label: "discord.js" });

--- a/src/index.ts
+++ b/src/index.ts
@@ -45,7 +45,7 @@ const client = new Discord.Client({
         ThreadMemberManager: 0,
         // keep user cache default, because guild member cache depends on it
         // UserManager: 0,
-        VoiceStateManager: Infinity,
+        VoiceStateManager: Number.POSITIVE_INFINITY,
     }),
 });
 
@@ -77,7 +77,7 @@ process.on("unhandledRejection", (reason, promise) => {
 });
 
 client.on("debug", message => {
-    if (/heartbeat/ig.test(message)) return;
+    if (/heartbeat/gi.test(message)) return;
     djs_log.debug(message);
 });
 

--- a/src/log.ts
+++ b/src/log.ts
@@ -1,8 +1,8 @@
-import { ENVIRONMENT, EnvironmentStages } from "./config.js";
-
 import chalk from "chalk";
 import winston from "winston";
 import "winston-daily-rotate-file";
+
+import { ENVIRONMENT, EnvironmentStages, LOGS_DIR } from "./config.js";
 
 const levels = {
     error: 0,
@@ -20,7 +20,6 @@ winston.addColors({
     debug: "white",
 });
 
-const LOGS_DIR = "logs/";
 const rotate_file_opts = {
     datePattern: "YYYY-MM-DD",
     zippedArchive: true,
@@ -54,12 +53,12 @@ const Logger = winston.createLogger({
         }),
         new winston.transports.DailyRotateFile({
             ...rotate_file_opts,
-            filename: `${LOGS_DIR}%DATE%-bot-error.log`,
+            filename: `${LOGS_DIR}/%DATE%-bot-error.log`,
             level: "error",
         }),
         new winston.transports.DailyRotateFile({
             ...rotate_file_opts,
-            filename: `${LOGS_DIR}%DATE%-bot-combined.log`,
+            filename: `${LOGS_DIR}/%DATE%-bot-combined.log`,
             level: "debug",
         }),
     ],

--- a/src/log.ts
+++ b/src/log.ts
@@ -1,4 +1,4 @@
-import { ENVIRONMENT, EnvironmentStages } from "./config";
+import { ENVIRONMENT, EnvironmentStages } from "./config.js";
 
 import chalk from "chalk";
 import winston from "winston";

--- a/src/modules/charts/index.ts
+++ b/src/modules/charts/index.ts
@@ -1,7 +1,7 @@
 import path from "node:path";
-import { createWorker } from "../../util/worker";
+import { createWorker } from "../../util/worker/index.js";
 import * as Comlink from "comlink";
-import nodeEndpoint from "comlink/dist/umd/node-adapter";
+import nodeEndpoint from "comlink/dist/umd/node-adapter.js";
 
 const worker = createWorker(path.resolve(__dirname, "worker.ts"));
 

--- a/src/modules/charts/index.ts
+++ b/src/modules/charts/index.ts
@@ -1,8 +1,10 @@
 import path from "node:path";
-import { createWorker } from "../../util/worker/index.js";
 import * as Comlink from "comlink";
 import nodeEndpoint from "comlink/dist/umd/node-adapter.js";
 
-const worker = createWorker(path.resolve(__dirname, "worker.ts"));
+import { createWorker } from "../../util/worker/index.js";
+import { getDirname } from "../../util/esm.js";
+
+const worker = createWorker(path.resolve(getDirname(import.meta.url), "worker.ts"));
 
 export default Comlink.wrap<import("./worker").WorkerAPI>(nodeEndpoint(worker));

--- a/src/modules/charts/line.ts
+++ b/src/modules/charts/line.ts
@@ -6,11 +6,11 @@ import color from "color";
 import moment from "moment";
 
 import { lastItem } from "../../util/array.js";
-import { PROJECT_ROOT } from "../../config.js";
+import { ASSETS_DIR } from "../../config.js";
 import { COLOR } from "../../const.js";
 
-registerFont(path.join(PROJECT_ROOT, "assets", "fonts", "Roboto-Regular.ttf"), { family: "Roboto", weight: "normal" });
-registerFont(path.join(PROJECT_ROOT, "assets", "fonts", "Roboto-Bold.ttf"), { family: "Roboto", weight: "bold" });
+registerFont(path.join(ASSETS_DIR, "fonts", "Roboto-Regular.ttf"), { family: "Roboto", weight: "normal" });
+registerFont(path.join(ASSETS_DIR, "fonts", "Roboto-Bold.ttf"), { family: "Roboto", weight: "bold" });
 
 const WHITE_COLOR = color(COLOR.CHART_BG, "rgb").string();
 const LEGEND_TEXT_COLOR = color(COLOR.CHART_FG, "rgb").mix(color(COLOR.CHART_BG, "rgb"), 0.4).string();

--- a/src/modules/charts/line.ts
+++ b/src/modules/charts/line.ts
@@ -1,11 +1,13 @@
-import { createCanvas, CanvasRenderingContext2D, registerFont } from "canvas";
+// required way to import, because canvas' named exports are messed up when importing from ESM
+import canvasPackage, { CanvasRenderingContext2D } from "canvas";
+const { createCanvas, registerFont } = canvasPackage;
 import path from "node:path";
 import color from "color";
 import moment from "moment";
 
-import { lastItem } from "../../util/array";
-import { PROJECT_ROOT } from "../../config";
-import { COLOR } from "../../const";
+import { lastItem } from "../../util/array.js";
+import { PROJECT_ROOT } from "../../config.js";
+import { COLOR } from "../../const.js";
 
 registerFont(path.join(PROJECT_ROOT, "assets", "fonts", "Roboto-Regular.ttf"), { family: "Roboto", weight: "normal" });
 registerFont(path.join(PROJECT_ROOT, "assets", "fonts", "Roboto-Bold.ttf"), { family: "Roboto", weight: "bold" });

--- a/src/modules/charts/worker.ts
+++ b/src/modules/charts/worker.ts
@@ -1,9 +1,9 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 import { parentPort } from "node:worker_threads";
 import * as Comlink from "comlink";
-import nodeEndpoint from "comlink/dist/umd/node-adapter";
-import Logger from "../../log";
-import { lineGraph } from "./line";
+import nodeEndpoint from "comlink/dist/umd/node-adapter.js";
+import Logger from "../../log.js";
+import { lineGraph } from "./line.js";
 
 const log = Logger.child({ label: "Charts => Worker" });
 

--- a/src/modules/charts/worker.ts
+++ b/src/modules/charts/worker.ts
@@ -2,6 +2,7 @@
 import { parentPort } from "node:worker_threads";
 import * as Comlink from "comlink";
 import nodeEndpoint from "comlink/dist/umd/node-adapter.js";
+
 import Logger from "../../log.js";
 import { lineGraph } from "./line.js";
 

--- a/src/modules/commands/Command.ts
+++ b/src/modules/commands/Command.ts
@@ -1,8 +1,8 @@
 import Discord from "discord.js";
-import Logger from "../../log";
-import nanoTimer from "../../util/timer";
-import { BaseCommandOption } from "./CommandOption";
-import { SimpleFunc } from "./types";
+import Logger from "../../log.js";
+import nanoTimer from "../../util/timer.js";
+import { BaseCommandOption } from "./CommandOption.js";
+import { SimpleFunc } from "./types/index.js";
 
 const log = Logger.child({ label: "Command => autocomplete" });
 

--- a/src/modules/commands/Command.ts
+++ b/src/modules/commands/Command.ts
@@ -1,4 +1,5 @@
 import Discord from "discord.js";
+
 import Logger from "../../log.js";
 import nanoTimer from "../../util/timer.js";
 import { BaseCommandOption } from "./CommandOption.js";

--- a/src/modules/commands/Command.ts
+++ b/src/modules/commands/Command.ts
@@ -62,8 +62,7 @@ export class Command {
         const result = await this.func(interaction);
         if (!result || interaction.replied) return;
 
-        if (interaction.deferred) await interaction.editReply(result);
-        else await interaction.reply(result);
+        await (interaction.deferred ? interaction.editReply(result) : interaction.reply(result));
     }
 
     toJSON(): any { // need return type any for TopCommand to work

--- a/src/modules/commands/CommandGroup.ts
+++ b/src/modules/commands/CommandGroup.ts
@@ -1,6 +1,6 @@
 import Discord from "discord.js";
-import { Command } from "./Command";
-import { MiddlewareFunc } from "./types";
+import { Command } from "./Command.js";
+import { MiddlewareFunc } from "./types/index.js";
 
 export interface CommandGroupOptions {
     name: string;

--- a/src/modules/commands/CommandGroup.ts
+++ b/src/modules/commands/CommandGroup.ts
@@ -1,4 +1,5 @@
 import Discord from "discord.js";
+
 import { Command } from "./Command.js";
 import { MiddlewareFunc } from "./types/index.js";
 

--- a/src/modules/commands/CommandOption.ts
+++ b/src/modules/commands/CommandOption.ts
@@ -1,5 +1,6 @@
 import Discord from "discord.js";
-import { ChannelTypes } from "discord.js/typings/enums.js";
+import { ChannelTypes } from "discord.js/typings/enums";
+
 import { ApplicationCommandOptionChoice } from "./options/createChoice.js";
 
 export type CommandOptionAutocompleteFunc<T = any> = (value: T, interaction: Discord.AutocompleteInteraction) => Discord.Awaitable<Discord.ApplicationCommandOptionChoice[]>;

--- a/src/modules/commands/CommandOption.ts
+++ b/src/modules/commands/CommandOption.ts
@@ -1,6 +1,6 @@
 import Discord from "discord.js";
-import { ChannelTypes } from "discord.js/typings/enums";
-import { ApplicationCommandOptionChoice } from "./options/createChoice";
+import { ChannelTypes } from "discord.js/typings/enums.js";
+import { ApplicationCommandOptionChoice } from "./options/createChoice.js";
 
 export type CommandOptionAutocompleteFunc<T = any> = (value: T, interaction: Discord.AutocompleteInteraction) => Discord.Awaitable<Discord.ApplicationCommandOptionChoice[]>;
 

--- a/src/modules/commands/TopCommand.ts
+++ b/src/modules/commands/TopCommand.ts
@@ -1,6 +1,6 @@
 import Discord from "discord.js";
-import { Command, CommandOptions } from "./Command";
-import { GuildCreateEventHandler, CommandTarget } from "./types";
+import { Command, CommandOptions } from "./Command.js";
+import { GuildCreateEventHandler, CommandTarget } from "./types/index.js";
 
 export interface TopCommandOptions extends CommandOptions {
     target?: CommandTarget;

--- a/src/modules/commands/TopCommand.ts
+++ b/src/modules/commands/TopCommand.ts
@@ -9,7 +9,7 @@ export interface TopCommandOptions extends CommandOptions {
 }
 
 export class TopCommand extends Command {
-    app_command: Discord.ApplicationCommand | null = null;
+    app_command?: Discord.ApplicationCommand;
     target: CommandTarget;
 
     onGuildCreate?: GuildCreateEventHandler;

--- a/src/modules/commands/TopCommand.ts
+++ b/src/modules/commands/TopCommand.ts
@@ -1,6 +1,7 @@
 import Discord from "discord.js";
+
 import { Command, CommandOptions } from "./Command.js";
-import { GuildCreateEventHandler, CommandTarget } from "./types/index.js";
+import { CommandTarget, GuildCreateEventHandler } from "./types/index.js";
 
 export interface TopCommandOptions extends CommandOptions {
     target?: CommandTarget;

--- a/src/modules/commands/TopCommandGroup.ts
+++ b/src/modules/commands/TopCommandGroup.ts
@@ -14,7 +14,7 @@ export interface TopCommandGroupOptions {
 }
 
 export class TopCommandGroup extends CommandGroup {
-    app_command: Discord.ApplicationCommand | null = null;
+    app_command?: Discord.ApplicationCommand;
     target: CommandTarget;
 
     onGuildCreate?: GuildCreateEventHandler;

--- a/src/modules/commands/TopCommandGroup.ts
+++ b/src/modules/commands/TopCommandGroup.ts
@@ -1,7 +1,7 @@
 import Discord from "discord.js";
-import { Command } from "./Command";
-import { CommandGroup } from "./CommandGroup";
-import { CommandTarget, GuildCreateEventHandler, MiddlewareFunc } from "./types";
+import { Command } from "./Command.js";
+import { CommandGroup } from "./CommandGroup.js";
+import { CommandTarget, GuildCreateEventHandler, MiddlewareFunc } from "./types/index.js";
 
 export interface TopCommandGroupOptions {
     name: string;

--- a/src/modules/commands/TopCommandGroup.ts
+++ b/src/modules/commands/TopCommandGroup.ts
@@ -1,4 +1,5 @@
 import Discord from "discord.js";
+
 import { Command } from "./Command.js";
 import { CommandGroup } from "./CommandGroup.js";
 import { CommandTarget, GuildCreateEventHandler, MiddlewareFunc } from "./types/index.js";

--- a/src/modules/database/DatabaseCache.ts
+++ b/src/modules/database/DatabaseCache.ts
@@ -1,8 +1,8 @@
 import { Collection, Document, Filter, FindCursor, FindOneAndReplaceOptions, FindOneAndUpdateOptions, FindOptions, OptionalId, UpdateFilter } from "mongodb";
 import { Except } from "type-fest";
 
-import Cache, { CacheOptions } from "../Cache";
-import * as database from ".";
+import Cache, { CacheOptions } from "../Cache.js";
+import * as database from "./index.js";
 
 export interface DatabaseCacheOptions<KeyName> extends CacheOptions {
     indexName: KeyName;

--- a/src/modules/database/DatabaseCache.ts
+++ b/src/modules/database/DatabaseCache.ts
@@ -1,3 +1,6 @@
+// Disable these because unicorn is stupid
+/* eslint-disable unicorn/no-array-callback-reference */
+/* eslint-disable unicorn/no-array-method-this-argument */
 import { Collection, Document, Filter, FindCursor, FindOneAndReplaceOptions, FindOneAndUpdateOptions, FindOptions, OptionalId, UpdateFilter } from "mongodb";
 import { Except } from "type-fest";
 
@@ -68,7 +71,7 @@ export default class DatabaseCache<
         return requirements.every(a => a);
     }
 
-    private _findOne(filter: CacheFilter<TSchema>): TSchema | null {
+    private _findOne(filter: CacheFilter<TSchema>): TSchema | undefined {
         // find documents quicker if filter includes index key
         if (typeof filter[this.index_name] !== "undefined") {
             const return_val = this.cache.get(filter[this.index_name] as KeyType);
@@ -77,25 +80,25 @@ export default class DatabaseCache<
                 if (this._filter(return_val, filter)) return return_val;
                 // else directly return, because since this was an indexed field search,
                 // the answer won't be in other parts of the cache
-                return null;
+                return;
             }
         }
 
         return this.cache.find(item => {
             return this._filter(item, filter);
-        }) ?? null;
+        });
     }
 
     // publics
 
-    async findOne(filter: CacheFilter<TSchema>): Promise<TSchema | null> {
-        let doc: TSchema | null;
+    async findOne(filter: CacheFilter<TSchema>): Promise<TSchema | undefined> {
+        let doc: TSchema | undefined;
 
         doc = this._findOne(filter);
         if (doc) return doc;
 
-        doc = await this.collection.findOne(filter);
-        if (!doc) return null;
+        doc = await this.collection.findOne(filter) ?? undefined;
+        if (!doc) return;
 
         this.cache.set(doc[this.index_name], doc);
 
@@ -124,7 +127,7 @@ export default class DatabaseCache<
 
     // async insertMany();
 
-    async updateOne(filter: CacheFilter<TSchema>, update: UpdateFilter<TSchema>, opts?: Except<FindOneAndUpdateOptions, "returnDocument">): Promise<TSchema | null> {
+    async updateOne(filter: CacheFilter<TSchema>, update: UpdateFilter<TSchema>, opts?: Except<FindOneAndUpdateOptions, "returnDocument">): Promise<TSchema | undefined> {
         const result = await this.collection.findOneAndUpdate(
             filter,
             update,
@@ -142,11 +145,9 @@ export default class DatabaseCache<
         // then delete it from cache, so there aren't any confusions
         const doc = this._findOne(filter);
         if (doc) this.cache.delete(doc[this.index_name]);
-
-        return null;
     }
 
-    async replaceOne(filter: CacheFilter<TSchema>, replacement: TSchema, opts: FindOneAndReplaceOptions = {}): Promise<TSchema | null> {
+    async replaceOne(filter: CacheFilter<TSchema>, replacement: TSchema, opts: FindOneAndReplaceOptions = {}): Promise<TSchema | undefined> {
         const result = await this.collection.findOneAndReplace(
             filter,
             replacement,
@@ -164,8 +165,6 @@ export default class DatabaseCache<
         // then delete it from cache, so there aren't any confusions
         const doc = this._findOne(filter);
         if (doc) this.cache.delete(doc[this.index_name]);
-
-        return null;
     }
 
     // async updateMany();

--- a/src/modules/database/databaseProxy.ts
+++ b/src/modules/database/databaseProxy.ts
@@ -1,5 +1,5 @@
 import { Collection, Document } from "mongodb";
-import * as database from ".";
+import * as database from "./index.js";
 
 // A lot of typescript cheating to make this proxy wrap
 // around the db client getter from database/index.ts

--- a/src/modules/database/databaseProxy.ts
+++ b/src/modules/database/databaseProxy.ts
@@ -1,4 +1,5 @@
 import { Collection, Document } from "mongodb";
+
 import * as database from "./index.js";
 
 // A lot of typescript cheating to make this proxy wrap

--- a/src/modules/database/index.ts
+++ b/src/modules/database/index.ts
@@ -1,10 +1,10 @@
 import { Awaitable } from "discord.js";
 import { Db, Collection, MongoClient } from "mongodb";
 
-import { BOT_NAME, DB_URI } from "../../config";
-import Logger from "../../log";
-import { onExit } from "../../util/exit";
-import { logErr } from "../../util/util";
+import { BOT_NAME, DB_URI } from "../../config.js";
+import Logger from "../../log.js";
+import { onExit } from "../../util/exit.js";
+import { logErr } from "../../util/util.js";
 
 export type QueueFunction = () => Awaitable<void>;
 

--- a/src/modules/database/index.ts
+++ b/src/modules/database/index.ts
@@ -1,5 +1,5 @@
 import { Awaitable } from "discord.js";
-import { Db, Collection, MongoClient } from "mongodb";
+import { Collection, Db, MongoClient } from "mongodb";
 
 import { BOT_NAME, DB_URI } from "../../config.js";
 import Logger from "../../log.js";

--- a/src/modules/database/models.ts
+++ b/src/modules/database/models.ts
@@ -1,16 +1,16 @@
-import * as database from "./index";
+import * as database from "./index.js";
 
-import DatabaseCache from "./DatabaseCache";
-import databaseProxy from "./databaseProxy";
+import DatabaseCache from "./DatabaseCache.js";
+import databaseProxy from "./databaseProxy.js";
 
-import { BlacklistUserSchema } from "./schemas/BlacklistUserSchema";
-import { ConfigSchema } from "./schemas/ConfigSchema";
-import { InteractionRepliesSchema } from "./schemas/InteractionRepliesSchema";
-import { SoundboardCustomSampleSchema } from "./schemas/SoundboardCustomSampleSchema";
-import { SoundboardStandardSampleSchema } from "./schemas/SoundboardStandardSampleSchema";
-import { SoundboardSlotSchema } from "./schemas/SoundboardSlotsSchema";
-import { StatsSchema } from "./schemas/StatsSchema";
-import { VotesSchema } from "./schemas/VotesSchema";
+import { BlacklistUserSchema } from "./schemas/BlacklistUserSchema.js";
+import { ConfigSchema } from "./schemas/ConfigSchema.js";
+import { InteractionRepliesSchema } from "./schemas/InteractionRepliesSchema.js";
+import { SoundboardCustomSampleSchema } from "./schemas/SoundboardCustomSampleSchema.js";
+import { SoundboardStandardSampleSchema } from "./schemas/SoundboardStandardSampleSchema.js";
+import { SoundboardSlotSchema } from "./schemas/SoundboardSlotsSchema.js";
+import { StatsSchema } from "./schemas/StatsSchema.js";
+import { VotesSchema } from "./schemas/VotesSchema.js";
 
 export enum DbCollection {
     BlacklistUser = "blacklist_user",

--- a/src/modules/database/models.ts
+++ b/src/modules/database/models.ts
@@ -1,8 +1,6 @@
 import * as database from "./index.js";
-
 import DatabaseCache from "./DatabaseCache.js";
 import databaseProxy from "./databaseProxy.js";
-
 import { BlacklistUserSchema } from "./schemas/BlacklistUserSchema.js";
 import { ConfigSchema } from "./schemas/ConfigSchema.js";
 import { InteractionRepliesSchema } from "./schemas/InteractionRepliesSchema.js";

--- a/src/modules/database/schemas/SoundboardCustomSampleSchema.ts
+++ b/src/modules/database/schemas/SoundboardCustomSampleSchema.ts
@@ -1,5 +1,5 @@
-import { SAMPLE_TYPES } from "../../../const";
-import { SoundboardStandardSampleSchema } from "./SoundboardStandardSampleSchema";
+import { SAMPLE_TYPES } from "../../../const.js";
+import { SoundboardStandardSampleSchema } from "./SoundboardStandardSampleSchema.js";
 
 export type SoundboardCustomSampleScope = SAMPLE_TYPES.USER | SAMPLE_TYPES.SERVER;
 

--- a/src/modules/database/schemas/SoundboardSlotsSchema.ts
+++ b/src/modules/database/schemas/SoundboardSlotsSchema.ts
@@ -1,4 +1,4 @@
-import { SAMPLE_TYPES } from "../../../const";
+import { SAMPLE_TYPES } from "../../../const.js";
 
 export interface SoundboardSlot {
     ts: Date;

--- a/src/util/array.ts
+++ b/src/util/array.ts
@@ -8,8 +8,8 @@ export function findAndRemove<T>(arr: T[], elem: T): void {
 }
 
 export function findFirstIndex<T>(arr: T[], finder: (item: T) => boolean): number {
-    for (let i = 0; i < arr.length; i++) {
-        if (finder(arr[i])) return i;
+    for (const [i, element] of arr.entries()) {
+        if (finder(element)) return i;
     }
     return arr.length;
 }

--- a/src/util/banner_printer.ts
+++ b/src/util/banner_printer.ts
@@ -3,7 +3,7 @@ import Discord from "discord.js";
 import fs from "fs-extra";
 import path from "node:path";
 import { PackageJson } from "type-fest";
-import { ENVIRONMENT } from "../config";
+import { ENVIRONMENT } from "../config.js";
 
 const package_json: PackageJson = fs.readJSONSync(path.join(process.cwd(), "package.json"));
 

--- a/src/util/banner_printer.ts
+++ b/src/util/banner_printer.ts
@@ -1,5 +1,4 @@
 import Discord from "discord.js";
-
 import fs from "fs-extra";
 import path from "node:path";
 import { PackageJson } from "type-fest";

--- a/src/util/banner_printer.ts
+++ b/src/util/banner_printer.ts
@@ -2,9 +2,10 @@ import Discord from "discord.js";
 import fs from "fs-extra";
 import path from "node:path";
 import { PackageJson } from "type-fest";
-import { ENVIRONMENT } from "../config.js";
 
-const package_json: PackageJson = fs.readJSONSync(path.join(process.cwd(), "package.json"));
+import { ASSETS_DIR, ENVIRONMENT, PROJECT_ROOT } from "../config.js";
 
-const txt = fs.readFileSync(path.join(process.cwd(), "assets", "banner.txt"), "utf8");
+const package_json: PackageJson = fs.readJSONSync(path.join(PROJECT_ROOT, "package.json"));
+
+const txt = fs.readFileSync(path.join(ASSETS_DIR, "banner.txt"), "utf8");
 console.log(txt, package_json.version, ENVIRONMENT, Discord.version);

--- a/src/util/builders/dialog.ts
+++ b/src/util/builders/dialog.ts
@@ -1,9 +1,10 @@
 import { randomUUID } from "node:crypto";
 import Discord from "discord.js";
+
 import { BUTTON_TYPES } from "../../const.js";
 import InteractionRegistry, { ButtonParsed } from "../../core/InteractionRegistry.js";
 import { doNothing } from "../util.js";
-import { createEmbed, EmbedType } from "./embed.js";
+import { EmbedType, createEmbed } from "./embed.js";
 
 export interface DialogOptionsButton {
     id: ButtonParsed;

--- a/src/util/builders/dialog.ts
+++ b/src/util/builders/dialog.ts
@@ -1,9 +1,9 @@
-import { randomUUID } from "crypto";
+import { randomUUID } from "node:crypto";
 import Discord from "discord.js";
-import { BUTTON_TYPES } from "../../const";
-import InteractionRegistry, { ButtonParsed } from "../../core/InteractionRegistry";
-import { doNothing } from "../util";
-import { createEmbed, EmbedType } from "./embed";
+import { BUTTON_TYPES } from "../../const.js";
+import InteractionRegistry, { ButtonParsed } from "../../core/InteractionRegistry.js";
+import { doNothing } from "../util.js";
+import { createEmbed, EmbedType } from "./embed.js";
 
 export interface DialogOptionsButton {
     id: ButtonParsed;

--- a/src/util/builders/embed.ts
+++ b/src/util/builders/embed.ts
@@ -1,5 +1,5 @@
-import { COLOR, EMOJI } from "../../const";
 import Discord from "discord.js";
+import { COLOR, EMOJI } from "../../const.js";
 
 export enum EmbedType {
     Basic,

--- a/src/util/builders/embed.ts
+++ b/src/util/builders/embed.ts
@@ -1,4 +1,5 @@
 import Discord from "discord.js";
+
 import { COLOR, EMOJI } from "../../const.js";
 
 export enum EmbedType {

--- a/src/util/esm.ts
+++ b/src/util/esm.ts
@@ -1,0 +1,26 @@
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+
+/**
+ * Gets the directory name as a replacement for __dirname
+ *
+ * Use like:
+ * ```
+ * getDirname(import.meta.url);
+ * ```
+ */
+export function getDirname(url: string): string {
+    return path.dirname(fileURLToPath(url));
+}
+
+/**
+ * Gets the filename as a replacement for __filename
+ *
+ * Use like:
+ * ```
+ * getFilename(import.meta.url);
+ * ```
+ */
+export function getFilename(url: string): string {
+    return fileURLToPath(url);
+}

--- a/src/util/exit.ts
+++ b/src/util/exit.ts
@@ -1,6 +1,6 @@
 import temp from "temp";
 import { Awaitable } from "discord.js";
-import Logger from "../log";
+import Logger from "../log.js";
 
 temp.track();
 

--- a/src/util/exit.ts
+++ b/src/util/exit.ts
@@ -1,5 +1,6 @@
 import temp from "temp";
 import { Awaitable } from "discord.js";
+
 import Logger from "../log.js";
 
 temp.track();

--- a/src/util/files.ts
+++ b/src/util/files.ts
@@ -4,7 +4,7 @@ import { pipeline } from "node:stream/promises";
 import fetch from "node-fetch";
 import disk from "diskusage";
 
-import Logger from "../log";
+import Logger from "../log.js";
 
 const log = Logger.child({ label: "util => files" });
 

--- a/src/util/files.ts
+++ b/src/util/files.ts
@@ -25,10 +25,10 @@ export function walk(dir: string): Promise<string[]> {
                     if (stat && stat.isDirectory()) {
                         walk(file)
                             .then(files => {
-                                results = results.concat(files);
+                                results = [...results, ...files];
                                 if (!--pending) resolve(results);
                             })
-                            .catch(err => reject(err));
+                            .catch(error => reject(error));
                     } else {
                         results.push(file);
                         if (!--pending) resolve(results);
@@ -49,6 +49,7 @@ export async function isEnoughDiskSpace(): Promise<boolean> {
 export async function downloadFile(url: string, out_file: string): Promise<void> {
     const res = await fetch(url);
     if (!res.ok) throw new Error("Resource not accessible");
+    if (!res.body) throw new Error("node-fetch.Response.body is undefined");
 
     await pipeline(
         res.body,

--- a/src/util/types.ts
+++ b/src/util/types.ts
@@ -10,5 +10,6 @@ export interface CmdInstallerArgs {
 }
 
 export type CmdInstallerFileFunc = (opts: CmdInstallerArgs) => (Promise<void> | void);
-export type CmdInstallerFile =
-    & { install?: CmdInstallerFileFunc; };
+export interface CmdInstallerFile {
+    install?: CmdInstallerFileFunc;
+}

--- a/src/util/util.ts
+++ b/src/util/util.ts
@@ -1,4 +1,4 @@
-import { OWNER_IDS } from "../config";
+import { OWNER_IDS } from "../config.js";
 import Discord from "discord.js";
 
 export function isOwner(userId: Discord.Snowflake): boolean {

--- a/src/util/util.ts
+++ b/src/util/util.ts
@@ -1,5 +1,6 @@
-import { OWNER_IDS } from "../config.js";
 import Discord from "discord.js";
+
+import { OWNER_IDS } from "../config.js";
 
 export function isOwner(userId: Discord.Snowflake): boolean {
     return OWNER_IDS.includes(userId);

--- a/src/util/util.ts
+++ b/src/util/util.ts
@@ -18,11 +18,11 @@ export async function fetchMember(
     guild: Discord.Guild,
     user: Discord.UserResolvable,
     cache: boolean = true,
-): Promise<Discord.GuildMember | null> {
+): Promise<Discord.GuildMember | undefined> {
     try {
         return await guild.members.fetch({ user, cache });
     } catch {
-        return null;
+        return undefined;
     }
 }
 

--- a/src/util/worker/index.ts
+++ b/src/util/worker/index.ts
@@ -1,5 +1,6 @@
 import path from "node:path";
 import { Worker } from "node:worker_threads";
+
 import { getDirname } from "../esm.js";
 
 export function createWorker(worker_path: string): Worker {

--- a/src/util/worker/index.ts
+++ b/src/util/worker/index.ts
@@ -5,7 +5,7 @@ import { getDirname } from "../esm.js";
 
 export function createWorker(worker_path: string): Worker {
     return new Worker(
-        path.extname(__filename) === ".ts" ? path.resolve(__dirname, "./worker-portal.js") : worker_path.replace(/\.ts$/, ".js"),
+        /\.ts$/.test(import.meta.url) ? path.resolve(getDirname(import.meta.url), "./worker-portal.js") : worker_path.replace(/\.ts$/, ".js"),
         { workerData: { workerPath: worker_path } },
     );
 }

--- a/src/util/worker/index.ts
+++ b/src/util/worker/index.ts
@@ -1,5 +1,6 @@
 import path from "node:path";
 import { Worker } from "node:worker_threads";
+import { getDirname } from "../esm.js";
 
 export function createWorker(worker_path: string): Worker {
     return new Worker(

--- a/src/util/worker/worker-portal.js
+++ b/src/util/worker/worker-portal.js
@@ -3,8 +3,8 @@
  * Node.js only supports .js, .mjs, .cjs file extentions on Worker classes
  */
 
-const { workerData } = require("node:worker_threads");
+import { workerData } from "node:worker_threads";
 
-require("ts-node").register();
+(await import("ts-node")).register();
 // resolve to source dir
-require(workerData.workerPath);
+await import(workerData.workerPath);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,8 +7,14 @@
         "outDir": "./dist" /* Redirect output structure to the directory. */,
         "rootDir": "./src" /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */,
 
-        "resolveJsonModule": true
+        // "allowSyntheticDefaultImports": true,
+        // "isolatedModules": true,
+        "strict": true,
+        "module": "esnext",
+        // "lib": ["ES2019"],
+        "moduleResolution": "node",
+        // "skipLibCheck": true
     },
     "include": ["./src/**/*"],
-    "exclude": ["node_modules"]
+    "exclude": ["node_modules", "dist"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,11 +9,8 @@
 
         // "allowSyntheticDefaultImports": true,
         // "isolatedModules": true,
-        "strict": true,
         "module": "esnext",
-        // "lib": ["ES2019"],
-        "moduleResolution": "node",
-        // "skipLibCheck": true
+        "moduleResolution": "node"
     },
     "include": ["./src/**/*"],
     "exclude": ["node_modules", "dist"]


### PR DESCRIPTION
This PR makes compiling to ECMAScript Modules possible. With it come potential performance improvements and also 2 of the used packages can be updated to a new version, since they only support ESM going forward.

**Status**
- [x] Code changes have been tested and are working, or there are no code changes.
- [x] I ran `npm run lint` to ensure there to be no errors, or there are no code changes.

**Semantic versioning classification:**  
- [ ] This PR changes the bot's interface (commands added)
  - [ ] This PR includes breaking changes (commands moved or removed, or execution of commands changed)
- [ ] This PR **only** includes non-code changes, like changes to README, etc.
