### PR TITLE
Fix/fix double ts node register

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -18,9 +18,11 @@
             "args": [
                 "${workspaceFolder}/src/index.ts"
             ],
+            "console": "internalConsole", 
+            "outputCapture": "std",
         },
         {
-            "name": "Debug Build TS Project",
+            "name": "Debug Precompile TS Project",
             "type": "node",
             "request": "launch",
             "env": {
@@ -31,6 +33,8 @@
                 "${workspaceFolder}/dist/index.js"
             ],
             "preLaunchTask": "npm: build",
+            "console": "internalConsole", 
+            "outputCapture": "std",
         }
     ]
 }

--- a/src/util/worker/worker-portal.js
+++ b/src/util/worker/worker-portal.js
@@ -5,6 +5,9 @@
 
 const { workerData } = require("node:worker_threads");
 
-require("ts-node").register();
+// Check if ts-node is already registered in this context
+if (!process[Symbol.for("ts-node.register.instance")]) {
+    require("ts-node").register();
+}
 // resolve to source dir
 require(workerData.workerPath);


### PR DESCRIPTION
**Describe the bug**
Launching the debug profile, after the code has created the worker, the process quits with a node error passed on by the worker, I think.

Through step-by-step debugging I found the error message:
```
diagnosticText:'src/modules/canvas/worker.ts(2,5): error TS7022: '__createBinding' implicitly has type 'any' because it does not have a type annotation and is referenced directly or indirectly in its own initializer.
src/modules/canvas/worker.ts(2,58): error TS2774: This condition will always return true since this function is always defined. Did you mean to call it instead?
src/modules/canvas/worker.ts(2,84): error TS7006: Parameter 'o' implicitly has an 'any' type.
src/modules/canvas/worker.ts(2,87): error T…canvas/worker.ts(14,61): error TS7006: Parameter 'mod' implicitly has an 'any' type.
src/modules/canvas/worker.ts(21,5): error TS7022: '__importDefault' implicitly has type 'any' because it does not have a type annotation and is referenced directly or indirectly in its own initializer.
src/modules/canvas/worker.ts(21,67): error TS7006: Parameter 'mod' implicitly has an 'any' type.
src/modules/canvas/worker.ts(38,22): error TS2695: Left side of comma operator is unused and has no side effects.
```

It could be re-registering ts-node to the worker process? That's why it's type-checking the code generated by typescript? Just an idea.

**To Reproduce**
In VS Code, launch the task "Debug TS Project".

**Expected behavior**
The project will be able to finish startup and can be properly debugged.