### PR TITLE
feat: add volume control

### DIFF
--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -1,15 +1,15 @@
 import { BOT_NAME } from "../config";
 
 import InteractionRegistry from "../core/InteractionRegistry";
-import { EmbedType, replyEmbed } from "../util/builders/embed";
-import { CommandRoleOption } from "../modules/commands/CommandOption";
+import { createEmbed, EmbedType, replyEmbed } from "../util/builders/embed";
+import { ApplicationCommandOptionChoice, CommandNumberOption, CommandRoleOption } from "../modules/commands/CommandOption";
 import { TopCommandGroup } from "../modules/commands/TopCommandGroup";
 import { Command } from "../modules/commands/Command";
 
 import GuildConfigManager from "../core/data-managers/GuildConfigManager";
 
-const set_admin_role_cmd = new Command({
-    name: "set-admin-role",
+const admin_role_cmd = new Command({
+    name: "admin-role",
     description: `Set the (admin) role ${BOT_NAME} uses to allow / disallow access to admin commands.`,
     options: [
         new CommandRoleOption({
@@ -25,26 +25,68 @@ const set_admin_role_cmd = new Command({
 
         const role = interaction.options.getRole("role", true);
 
-        await GuildConfigManager.setAdminRole(interaction.guildId, role.id);
+        await GuildConfigManager.setAdminRole(interaction.guild, role.id);
 
         return replyEmbed("Set the role!", EmbedType.Success);
     },
 });
 
-const show_admin_role_cmd = new Command({
-    name: "show-admin-role",
-    description: `Shows the (admin) role ${BOT_NAME} uses to allow / disallow access to admin commands.`,
-    async func(interaction) {
-        if (!interaction.inCachedGuild()) return;
+// create an array of option choices in the interval of (0.0, 1.0]
+// sorted biggest to smallest
+const volume_steps_num = 10;
+// didn't know this was the way to create an array, but unicorn tells me to prefer this over `new Array(length)`
+const volume_steps: ApplicationCommandOptionChoice<number>[] = Array.from({ length: volume_steps_num });
+const volume_steps_diff = 100 / volume_steps_num;
+for (let i = volume_steps_num; i > 0; i--) {
+    volume_steps[volume_steps_num - i] = {
+        value: i / volume_steps_num,
+        name: `${Math.floor(i * volume_steps_diff)}%`,
+    };
+}
 
-        const config = await GuildConfigManager.findOrGenConfig(interaction.guild);
-        if (!config) {
+const volume_cmd = new Command({
+    name: "volume",
+    description: `Set ${BOT_NAME}'s loudness in voice channels.`,
+    options: [
+        new CommandNumberOption({
+            name: "level",
+            description: `The loudness level of ${BOT_NAME} in voice channels`,
+            required: true,
+            choices: volume_steps,
+        }),
+    ],
+    async func(interaction) {
+        if (!interaction.inCachedGuild() || !await GuildConfigManager.isModerator(interaction.guild, interaction.user.id)) {
             return;
         }
 
-        const role = await interaction.guild.roles.fetch(config.adminRoleId);
+        const volume = interaction.options.getNumber("level", true);
 
-        return replyEmbed(`Admin role is ${role?.toString()}`, EmbedType.Info);
+        await GuildConfigManager.setVolume(interaction.guild, volume);
+
+        return replyEmbed(`Volume set to ${Math.floor(volume * 100)}%!`, EmbedType.Success);
+    },
+});
+
+const show_cmd = new Command({
+    name: "show",
+    description: `Shows the configuration of ${BOT_NAME} in this server.`,
+    async func(interaction) {
+        if (!interaction.inCachedGuild()) return;
+
+        const config = await GuildConfigManager.findOrGenerateConfig(interaction.guild);
+        const role = await interaction.guild.roles.fetch(config.adminRoleId);
+        const volume = `${Math.floor(config.volume * 100)}%`;
+
+        const embed = createEmbed(undefined, EmbedType.Info)
+            .setAuthor({
+                name: `${interaction.guild.name} | ${BOT_NAME} Config`,
+                iconURL: interaction.guild.iconURL({ size: 32 }) ?? undefined,
+            })
+            .addField("Admin Role", `${role?.toString()}`, true)
+            .addField("Volume", volume, true);
+
+        return { embeds: [embed] };
     },
 });
 
@@ -52,16 +94,12 @@ InteractionRegistry.addCommand(new TopCommandGroup({
     name: "config",
     description: `Configure ${BOT_NAME} for your server.`,
     commands: [
-        set_admin_role_cmd,
-        show_admin_role_cmd,
+        admin_role_cmd,
+        volume_cmd,
+        show_cmd,
     ],
     target: {
         global: false,
         guildHidden: false,
-    },
-    // called every time the bot starts
-    async onGuildCreate(app_command, guild) {
-        // generate config
-        await GuildConfigManager.findOrGenConfig(guild);
     },
 }));

--- a/src/core/data-managers/GuildConfigManager.ts
+++ b/src/core/data-managers/GuildConfigManager.ts
@@ -2,73 +2,133 @@ import * as Discord from "discord.js";
 import { TypedEmitter } from "tiny-typed-emitter";
 
 import { fetchMember, guessModRole } from "../../util/util";
+import { omitProp } from "../../util/object";
+
 import * as models from "../../modules/database/models";
 import { GuildConfigSchema } from "../../modules/database/schemas/GuildConfigSchema";
 
 interface GuildConfigManagerEvents {
-    adminRoleChange(guildId: Discord.Snowflake, roleId: Discord.Snowflake): void;
+    adminRoleChange(guildId: Discord.Snowflake, adminRoleId: Discord.Snowflake): void;
+    volumeChange(guildId: Discord.Snowflake, volume: number): void;
 }
 
+/*
+ * Only fix a config, when it is fetched. Not when values are set, because
+ * that only increases unneccessary work-load, since config will be fixed
+ * when fetch anyways, so no one actually cares about the admin role being
+ * correct when setting the volume
+ */
+
 class GuildConfigManager extends TypedEmitter<GuildConfigManagerEvents> {
+    static DEFAULTS: Omit<GuildConfigSchema, "adminRoleId" | "guildId"> = {
+        volume: 1,
+    };
+
+    private generateDefaults(guild: Discord.Guild): Omit<GuildConfigSchema, "guildId"> {
+        // on insert, default to guessed mod role
+        const adminRoleId = guessModRole(guild).id;
+
+        return { ...GuildConfigManager.DEFAULTS, adminRoleId };
+    }
+
     public async removeConfig(guildId: Discord.Snowflake): Promise<void> {
         await models.guild_config.deleteOne({ guildId });
     }
 
-    public async setConfig(guildId: Discord.Snowflake, config: GuildConfigSchema): Promise<void> {
-        await models.guild_config.replaceOne({ guildId }, config, { upsert: true });
-    }
-
-    public async regenConfig(guild: Discord.Guild): Promise<void> {
-        const guessed_role = guessModRole(guild);
-
-        const config = await this.findOrGenConfig(guild);
-        if (config && config.adminRoleId === guessed_role.id) return;
-
+    public async createOrRegenerateConfig(guild: Discord.Guild): Promise<GuildConfigSchema> {
         // reset admin role to the highest role when rejoining
         // default to the highest role or a role that says "mod", "moderator"
         // or "admin" in the server (server with no roles this will be @everyone)
-        await this.setAdminRole(guild.id, guessed_role.id);
+        const $set = this.generateDefaults(guild);
+
+        await models.guild_config.updateOne(
+            { guildId: guild.id },
+            { $set },
+            { upsert: true },
+        );
+
+        this.emit("adminRoleChange", guild.id, $set.adminRoleId);
+        this.emit("volumeChange", guild.id, $set.volume);
+
+        return { guildId: guild.id, ...$set };
     }
 
     /**
      * Get an existing config from the database, check it's values and repair it, or create a new config if it doesn't exist
      */
-    public async findOrGenConfig(guild: Discord.Guild): Promise<GuildConfigSchema> {
-        const doc = await models.guild_config.findOne({ guildId: guild.id }) || { guildId: guild.id, adminRoleId: undefined };
-        const { guildId } = doc;
-        let { adminRoleId } = doc;
+    public async findOrGenerateConfig(guild: Discord.Guild): Promise<GuildConfigSchema> {
+        const doc = await models.guild_config.findOne({ guildId: guild.id });
+        if (!doc) {
+            return await this.createOrRegenerateConfig(guild);
+        }
+
+        const new_doc: GuildConfigSchema = { ...doc };
         let data_changed = false;
 
         // if old admin role has been deleted, default back to the guessed role
-        if (!adminRoleId || !await guild.roles.fetch(adminRoleId)) {
-            const guessed_role = guessModRole(guild);
-            adminRoleId = guessed_role.id;
+        if (!await guild.roles.fetch(doc.adminRoleId)) {
+            new_doc.adminRoleId = guessModRole(guild).id;
+            data_changed = true;
+        }
+        // for old-configs
+        if (typeof doc.volume === "undefined") {
+            new_doc.volume = GuildConfigManager.DEFAULTS.volume;
             data_changed = true;
         }
 
-        const config: GuildConfigSchema = { guildId, adminRoleId };
-
         if (data_changed) {
-            await this.setConfig(config.guildId, config);
+            await models.guild_config.replaceOne({ guildId: guild.id }, new_doc);
         }
 
-        return config;
+        return new_doc;
     }
 
-    public async setAdminRole(guildId: Discord.Snowflake, roleId: Discord.Snowflake): Promise<void> {
-        await this.setConfig(guildId, { guildId, adminRoleId: roleId });
+    public async setAdminRole(guild: Discord.Guild, adminRoleId: Discord.Snowflake): Promise<void> {
+        // The following types enforce that $set always includes all properties that
+        // do not have default values that need to be set in a DB document for semantic correctness
+        const $setOnInsert = GuildConfigManager.DEFAULTS;
+        const $set: Omit<GuildConfigSchema, keyof typeof $setOnInsert | "guildId"> = {
+            adminRoleId,
+        };
 
-        this.emit("adminRoleChange", guildId, roleId);
+        await models.guild_config.updateOne(
+            { guildId: guild.id },
+            { $set, $setOnInsert },
+            { upsert: true },
+        );
+
+        this.emit("adminRoleChange", guild.id, adminRoleId);
+    }
+
+    public async setVolume(guild: Discord.Guild, volume: number): Promise<void> {
+        if (volume > 1 || volume < 0) {
+            throw new TypeError("volume must be in 0.0...1.0");
+        }
+
+        // The following types enforce that $set always includes all properties that
+        // do not have default values that need to be set in a DB document for semantic correctness
+        // do not set default volume on insert, because we want to set our own value
+        const $setOnInsert = omitProp(this.generateDefaults(guild), "volume");
+        const $set: Omit<GuildConfigSchema, keyof typeof $setOnInsert | "guildId"> = {
+            volume,
+        };
+
+        await models.guild_config.updateOne(
+            { guildId: guild.id },
+            { $set, $setOnInsert },
+            { upsert: true },
+        );
+
+        this.emit("volumeChange", guild.id, volume);
     }
 
     public async isModerator(guild: Discord.Guild, userId: Discord.Snowflake): Promise<boolean> {
         const member = await fetchMember(guild, userId);
         if (!member) return false;
 
-        const config = await this.findOrGenConfig(guild);
-        if (!config) return false;
-
         if (member.permissions.has(Discord.Permissions.FLAGS.ADMINISTRATOR)) return true;
+
+        const config = await this.findOrGenerateConfig(guild);
 
         if (member.roles.cache.has(config.adminRoleId)) return true;
 

--- a/src/core/events/onGuildCreate.ts
+++ b/src/core/events/onGuildCreate.ts
@@ -7,6 +7,6 @@ export default function onGuildCreate() {
     return async (guild: Discord.Guild): Promise<void> => {
         await DataDeletionManager.unmarkGuildForDeletion(guild.id);
 
-        await GuildConfigManager.regenConfig(guild);
+        await GuildConfigManager.createOrRegenerateConfig(guild);
     };
 }

--- a/src/core/soundboard/AbstractSample.ts
+++ b/src/core/soundboard/AbstractSample.ts
@@ -35,10 +35,16 @@ export abstract class AbstractSample implements SoundboardStandardSampleSchema {
 
     abstract get file(): string;
 
-    protected _play(audio_player: Voice.AudioPlayer): Voice.AudioResource<AbstractSample> {
+    protected _play(audio_player: Voice.AudioPlayer, volume: number): Voice.AudioResource<AbstractSample> {
         // Attempt to convert the Sound into an AudioResource
         const stream = fs.createReadStream(this.file);
-        const resource = Voice.createAudioResource(stream, { metadata: this, inputType: Voice.StreamType.OggOpus });
+        const resource = Voice.createAudioResource(stream, {
+            metadata: this,
+            inputType: Voice.StreamType.OggOpus,
+            inlineVolume: volume < 1,
+        });
+        // resource.volume is undefined when inlineVolume is false => when volume == 1
+        if (resource.volume) resource.volume.setVolume(volume);
 
         /*
         We will now play this to the audio player. By default, the audio player will not play until
@@ -50,7 +56,7 @@ export abstract class AbstractSample implements SoundboardStandardSampleSchema {
         return resource;
     }
 
-    abstract play(audio_player: Voice.AudioPlayer): Promise<Voice.AudioResource<AbstractSample>>;
+    abstract play(audio_player: Voice.AudioPlayer, volume: number): Promise<Voice.AudioResource<AbstractSample>>;
 
     abstract toEmbed(opts: ToEmbedOptions): Promise<Discord.InteractionReplyOptions>;
 

--- a/src/core/soundboard/CustomSample.ts
+++ b/src/core/soundboard/CustomSample.ts
@@ -52,10 +52,10 @@ export class CustomSample extends AbstractSample implements SoundboardCustomSamp
         return CustomSample.generateFilePath(this.id);
     }
 
-    async play(audio_player: Voice.AudioPlayer): Promise<Voice.AudioResource<AbstractSample>> {
+    async play(audio_player: Voice.AudioPlayer, volume: number): Promise<Voice.AudioResource<AbstractSample>> {
         log.debug("Playing custom sample %s (%s)", this.id, this.name);
 
-        const resource = this._play(audio_player);
+        const resource = this._play(audio_player, volume);
 
         const now = new Date();
 

--- a/src/core/soundboard/StandardSample.ts
+++ b/src/core/soundboard/StandardSample.ts
@@ -43,10 +43,10 @@ export class StandardSample extends AbstractSample implements SoundboardStandard
         return StandardSample.generateFilePath(this.name);
     }
 
-    async play(audio_player: Voice.AudioPlayer): Promise<Voice.AudioResource<AbstractSample>> {
+    async play(audio_player: Voice.AudioPlayer, volume: number): Promise<Voice.AudioResource<AbstractSample>> {
         log.debug("Playing standard sample %s", this.name);
 
-        const resource = this._play(audio_player);
+        const resource = this._play(audio_player, volume);
 
         const now = new Date();
 

--- a/src/modules/database/schemas/GuildConfigSchema.ts
+++ b/src/modules/database/schemas/GuildConfigSchema.ts
@@ -1,4 +1,5 @@
 export interface GuildConfigSchema {
     guildId: string;
     adminRoleId: string;
+    volume: number;
 }

--- a/src/util/object.ts
+++ b/src/util/object.ts
@@ -1,0 +1,8 @@
+/**
+ * Excludes a property from an object
+ */
+export function omitProp<T extends object, K extends keyof T>(obj: T, prop: K): Omit<T, K> {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const { [prop]: _, ...rest } = obj;
+    return rest;
+}


### PR DESCRIPTION
Often Soundbort is way too loud for the normal voice chat and everyone having to turn down the bots volume on their side is not a pleasent way to cope with it.
Therefore this PR brings support for a guild config property `volume` and the command `/config volume level:NUMBER`. It also adds a breaking change in command names: `/config set-admin-role` is now `/config admin-role` and `/config show-admin-role` is now `/config show` and shows the complete config.

The first draft of this feature just re-encodes the samples while they're being played. This of course adds load to the system for samples that are being played over and over, and also latency.
So the second draft should include caching the re-encoded samples to disk.

On that note, waveforms of samples should also be cached to disk. But that for another PR.