### PR TITLE
improvement: cache sound files in memory

### DIFF
--- a/src/modules/BufferCache.ts
+++ b/src/modules/BufferCache.ts
@@ -1,0 +1,63 @@
+/**
+ * Little Cache extension to cache buffers and set a maximum
+ * cache size in bytes
+ */
+
+import { Cache, CacheOptions, DEFAULTS as CacheDEFAULTS } from "./Cache";
+
+export interface BufferCacheOptions extends CacheOptions {
+    /**
+     * maximum cache size in bytes. 0 for no limit
+     */
+    maxByteSize?: number;
+}
+
+export const DEFAULTS: Required<BufferCacheOptions> = {
+    ...CacheDEFAULTS,
+    maxByteSize: 0,
+};
+
+export class BufferCache<K> extends Cache<K, Buffer> {
+    public readonly maxByteSize: number;
+
+    private _byteSize: number = 0;
+    public get byteSize(): number {
+        return this._byteSize;
+    }
+
+    constructor(opts: BufferCacheOptions = {}) {
+        super(opts);
+
+        this.maxByteSize = opts.maxByteSize ?? DEFAULTS.maxByteSize;
+    }
+
+    clear(): void {
+        super.clear();
+
+        this._byteSize = 0;
+    }
+
+    delete(key: K): boolean {
+        const buffer = this.get(key);
+        if (buffer) {
+            this._byteSize -= buffer.byteLength;
+        }
+
+        return super.delete(key);
+    }
+
+    set(key: K, buffer: Buffer): this {
+        if (this.maxByteSize > 0) {
+            // delete entries until the new element can be stored in the map
+            for (const key of this.keys()) {
+                if (this._byteSize + buffer.byteLength <= this.maxByteSize) break;
+
+                this.delete(key);
+            }
+        }
+
+        this._byteSize += buffer.byteLength;
+
+        return super.set(key, buffer);
+    }
+}

--- a/src/modules/Cache.ts
+++ b/src/modules/Cache.ts
@@ -9,7 +9,7 @@ export interface CacheOptions {
     maxSize?: number;
 }
 
-const DEFAULTS: Required<CacheOptions> = {
+export const DEFAULTS: Required<CacheOptions> = {
     maxSize: 0,
     ttl: 0,
 };
@@ -20,13 +20,11 @@ export class Cache<K, T> extends Map<K, T> {
 
     private _ttl: Map<K, NodeJS.Timeout> = new Map();
 
-    constructor(_opts: CacheOptions = {}) {
+    constructor(opts: CacheOptions = {}) {
         super();
 
-        const opts = { ...DEFAULTS, ..._opts } as Required<CacheOptions>;
-
-        this.ttl = opts.ttl * 1000;
-        this.maxSize = opts.maxSize;
+        this.ttl = (opts.ttl ?? DEFAULTS.ttl) * 1000;
+        this.maxSize = opts.maxSize ?? DEFAULTS.maxSize;
     }
 
     private _setTTLTimeout(key: K) {
@@ -102,8 +100,10 @@ export class Cache<K, T> extends Map<K, T> {
 
     set(key: K, new_doc: T): this {
         if (this.maxSize > 0 && this.size >= this.maxSize) {
-            const first_key = this.keys().next().value;
-            this.delete(first_key);
+            const first_key = this.keys().next();
+            if (!first_key.done) {
+                this.delete(first_key.value);
+            }
         }
 
         super.set(key, new_doc);


### PR DESCRIPTION
Cache the binary sound files in memory to improve access times.

**Status**
- [ ] Code changes have been tested and are working, or there are no code changes.
- [ ] I ran `npm run lint` and `npm run build` to ensure there to be no errors.

