### PR TITLE
chore: update to Node 18.10.0

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -6,7 +6,7 @@ If you wish to contribute to <NAME>, feel free to fork the repository and submit
 
 You need the following prerequisites for contributing to Soundbort:
 
-* Node.js 16.16.0 (using a version management tool like [nvm](https://github.com/nvm-sh/nvm) is recommended)
+* Node.js 18.10.0 (using a version management tool like [nvm](https://github.com/nvm-sh/nvm) is recommended)
 * build-essentials (apt install build-essential. For dev on Windows use WSL 2 or inform yourself about Node.js package build requirements)
 * ffmpeg (apt install ffmpeg)
 * A MongoDb instance. Either local, or on [cloud.mongodb.com](https://cloud.mongodb.com), which I recommend, because it's easy to setup, doesn't require you to install anything and it has a free plan.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM node:16.17-slim
+FROM node:18.10-slim
 
 LABEL maintainer="Christian Schäfer <lonelessart@gmail.com> (@lonelesscodes)"
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Soundbort is a custom soundboard bot for Discord. It offers low latency playback
 
 You need the following prerequisites for testing Soundbort:
 
-* Node.js 16.16.0 (using a version management tool like [nvm](https://github.com/nvm-sh/nvm) is recommended)
+* Node.js 18.10.0 (using a version management tool like [nvm](https://github.com/nvm-sh/nvm) is recommended)
 * build-essentials (apt install build-essential. For dev on Windows use WSL 2 or inform yourself about Node.js package build requirements)
 * ffmpeg (apt install ffmpeg)
 * A MongoDb instance. Either local, or on [cloud.mongodb.com](https://cloud.mongodb.com), which I recommend, because it's easy to setup, doesn't require you to install anything and it has a free plan.
@@ -103,6 +103,6 @@ This software comes WITHOUT ANY WARRANTY. Edit and use at your own risk!
 
 Soundbort is licensed under the [GNU General Public License v3.0](LICENSE)
 
-Copyright (C) 2021 Christian Schäfer / Loneless
+Copyright (C) 2022 Christian Schäfer / Loneless
 
 `Permissions of this strong copyleft license are conditioned on making available complete source code of licensed works and modifications, which include larger works using a licensed work, under the same license. Copyright and license notices must be preserved. Contributors provide an express grant of patent rights.`

--- a/package-lock.json
+++ b/package-lock.json
@@ -43,7 +43,7 @@
         "soundbort": "dist/cli.js"
       },
       "devDependencies": {
-        "@tsconfig/node16": "^1.0.3",
+        "@tsconfig/node18": "^1.0.1",
         "@types/color": "^3.0.3",
         "@types/concat-stream": "^2.0.0",
         "@types/cron": "^1.7.3",
@@ -64,7 +64,7 @@
         "typescript": "^4.8.4"
       },
       "engines": {
-        "node": ">= 16.14.0"
+        "node": ">= 18.10.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -516,6 +516,12 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.3.tgz",
       "integrity": "sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ==",
+      "dev": true
+    },
+    "node_modules/@tsconfig/node18": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node18/-/node18-1.0.1.tgz",
+      "integrity": "sha512-sNFeK6X2ATlhlvzyH4kKYQlfHXE2f2/wxtB9ClvYXevWpmwkUT7VaSrjIN9E76Qebz8qP5JOJJ9jD3QoD/Z9TA==",
       "dev": true
     },
     "node_modules/@types/body-parser": {
@@ -6414,6 +6420,12 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.3.tgz",
       "integrity": "sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ==",
+      "dev": true
+    },
+    "@tsconfig/node18": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node18/-/node18-1.0.1.tgz",
+      "integrity": "sha512-sNFeK6X2ATlhlvzyH4kKYQlfHXE2f2/wxtB9ClvYXevWpmwkUT7VaSrjIN9E76Qebz8qP5JOJJ9jD3QoD/Z9TA==",
       "dev": true
     },
     "@types/body-parser": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,9 +11,9 @@
       "dependencies": {
         "@discordjs/opus": "^0.8.0",
         "@discordjs/voice": "^0.13.0",
+        "@napi-rs/canvas": "^0.1.30",
         "@top-gg/sdk": "^3.1.3",
         "bufferutil": "^4.0.6",
-        "canvas": "^2.10.1",
         "chalk": "^4.1.2",
         "color": "^4.2.3",
         "comlink": "^4.3.1",
@@ -39,9 +39,6 @@
         "winston-daily-rotate-file": "^4.7.1",
         "zlib-sync": "^0.1.7"
       },
-      "bin": {
-        "soundbort": "dist/cli.js"
-      },
       "devDependencies": {
         "@tsconfig/node18": "^1.0.1",
         "@types/color": "^3.0.3",
@@ -64,7 +61,8 @@
         "typescript": "^4.8.4"
       },
       "engines": {
-        "node": ">= 18.10.0"
+        "node": ">= 18.10.0",
+        "npm": ">= 8.19.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -395,23 +393,162 @@
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
-    "node_modules/@mapbox/node-pre-gyp": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/@mapbox/node-pre-gyp/-/node-pre-gyp-1.0.10.tgz",
-      "integrity": "sha512-4ySo4CjzStuprMwk35H5pPbkymjv1SF3jGLj6rAHp/xT/RF7TL7bd9CTm1xDY49K2qF7jmR/g7k+SkLETP6opA==",
-      "dependencies": {
-        "detect-libc": "^2.0.0",
-        "https-proxy-agent": "^5.0.0",
-        "make-dir": "^3.1.0",
-        "node-fetch": "^2.6.7",
-        "nopt": "^5.0.0",
-        "npmlog": "^5.0.1",
-        "rimraf": "^3.0.2",
-        "semver": "^7.3.5",
-        "tar": "^6.1.11"
+    "node_modules/@napi-rs/canvas": {
+      "version": "0.1.30",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas/-/canvas-0.1.30.tgz",
+      "integrity": "sha512-XRR6PumJW9GdODD+HFW7ZKmpq7FE6PIKWn7QTcsJUdGNb54fTS1Z47oPFZ3pbvs07Xs8ZnkR03Q/9T3LfkGRgg==",
+      "engines": {
+        "node": ">= 10"
       },
-      "bin": {
-        "node-pre-gyp": "bin/node-pre-gyp"
+      "optionalDependencies": {
+        "@napi-rs/canvas-android-arm64": "0.1.30",
+        "@napi-rs/canvas-darwin-arm64": "0.1.30",
+        "@napi-rs/canvas-darwin-x64": "0.1.30",
+        "@napi-rs/canvas-linux-arm-gnueabihf": "0.1.30",
+        "@napi-rs/canvas-linux-arm64-gnu": "0.1.30",
+        "@napi-rs/canvas-linux-arm64-musl": "0.1.30",
+        "@napi-rs/canvas-linux-x64-gnu": "0.1.30",
+        "@napi-rs/canvas-linux-x64-musl": "0.1.30",
+        "@napi-rs/canvas-win32-x64-msvc": "0.1.30"
+      }
+    },
+    "node_modules/@napi-rs/canvas-android-arm64": {
+      "version": "0.1.30",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-android-arm64/-/canvas-android-arm64-0.1.30.tgz",
+      "integrity": "sha512-RaJvfg5x8QV+3WVqxwi1dt05mqiDuQF/w4wj8b6SHbxbVLfzZ5T0M9PFBTvjNU88GxiiVYUihxJeCCDs1sXP0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/canvas-darwin-arm64": {
+      "version": "0.1.30",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-arm64/-/canvas-darwin-arm64-0.1.30.tgz",
+      "integrity": "sha512-ZWW7+YYGFREzeV1uoGv0uUx+0OhGd5jQ6zFdaGYFESUjmLlfZ/LS0CG/IlbWDiWbnRPu2HQl0/TOQHurleJjLw==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/canvas-darwin-x64": {
+      "version": "0.1.30",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-x64/-/canvas-darwin-x64-0.1.30.tgz",
+      "integrity": "sha512-DThro7Y3QFV/9bl/EORWXzBMXeIZU1jo80oI8Ha2Xsoy3Eq+wHhnlMyvNYcLjalxIFU/JJrzu6/qxjPaVzcw5A==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm-gnueabihf": {
+      "version": "0.1.30",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm-gnueabihf/-/canvas-linux-arm-gnueabihf-0.1.30.tgz",
+      "integrity": "sha512-bMz85lH3y2JL7Xf8szu/EayyEffN2FSAUtxOm6U3/MLc7jW2Pt8TRhAQQxnv0zNh8ub7qBDky+LspMBPLTDRzA==",
+      "cpu": [
+        "arm"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm64-gnu": {
+      "version": "0.1.30",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-gnu/-/canvas-linux-arm64-gnu-0.1.30.tgz",
+      "integrity": "sha512-KHUVFOaG7wE4/GGTLk434GH7DIhPa7hhfMyzLqU1QFRXzjo0KIyO9gecHEF9snXaqvD4c/8YubEtFbWZVMSKUw==",
+      "cpu": [
+        "arm64"
+      ],
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm64-musl": {
+      "version": "0.1.30",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-musl/-/canvas-linux-arm64-musl-0.1.30.tgz",
+      "integrity": "sha512-9ckRCQbt/ZVNbHvApKhvaRM+mahMl4xryV0vUEKgFHo8Fm4j56dPZRWeKojmk1vSGC9ahY73K1MEb0OaIxOv0Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-x64-gnu": {
+      "version": "0.1.30",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-gnu/-/canvas-linux-x64-gnu-0.1.30.tgz",
+      "integrity": "sha512-NSyhCClsTBs06ViivDU0lSGVTDBBtm3pSTQKZseAnBEEF0vuO4De5SJl4JYng9eSDQ6KqA4TkOZFUMxokP6ZVg==",
+      "cpu": [
+        "x64"
+      ],
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-x64-musl": {
+      "version": "0.1.30",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-musl/-/canvas-linux-x64-musl-0.1.30.tgz",
+      "integrity": "sha512-hT3sPij6nHKiH10avrd8MNwLYEBzwiVyzA0nxPosGJ+ErWk1tgE4UeM3w1+BWYK3S/wgY/4WlhxDgsd9crUGRA==",
+      "cpu": [
+        "x64"
+      ],
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/canvas-win32-x64-msvc": {
+      "version": "0.1.30",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-x64-msvc/-/canvas-win32-x64-msvc-0.1.30.tgz",
+      "integrity": "sha512-6MwkIMd53jNqO+KAvv2A7TtMY1MYE51VCdF7sZ61sypgjB/dOYmYqDgAU/RTHS5agyc0CZUeXoaZT43Lkgk67A==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -1284,20 +1421,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/canvas": {
-      "version": "2.10.1",
-      "resolved": "https://registry.npmjs.org/canvas/-/canvas-2.10.1.tgz",
-      "integrity": "sha512-29pIjn9uwTUsIgJUNd7GXxKk8sg4iyJwLm1wIilNIqX1mVzXSc2nUij9exW1LqNpis1d2ebMYfMqTWcokZ4pdA==",
-      "hasInstallScript": true,
-      "dependencies": {
-        "@mapbox/node-pre-gyp": "^1.0.0",
-        "nan": "^2.15.0",
-        "simple-get": "^3.0.3"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -2044,17 +2167,6 @@
       "integrity": "sha512-hjf+xovcEn31w/EUYdTXQh/8smFL/dzYjohQGEIgjyNavaJfBY2p5F527Bo1VPATxv0VYTUC2bOcXvqFwk78Og==",
       "engines": {
         "node": ">=0.10"
-      }
-    },
-    "node_modules/decompress-response": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-4.2.1.tgz",
-      "integrity": "sha512-jOSne2qbyE+/r8G1VU+G/82LBs2Fs4LAsTiLSHOCOMZQl2OKZ6i8i4IyHemTe+/yIXOtTcRQMzPcgyhoFlqPkw==",
-      "dependencies": {
-        "mimic-response": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/deep-is": {
@@ -3957,17 +4069,6 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/mimic-response": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-2.1.0.tgz",
-      "integrity": "sha512-wXqjST+SLt7R009ySCglWBCFpjUygmCIfD790/kVbiGmUgfYGuB14PiTd5DwVxSV4NcYHjzMkoj5LjQZwTQLEA==",
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/min-indent": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
@@ -5045,35 +5146,6 @@
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="
-    },
-    "node_modules/simple-concat": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
-      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ]
-    },
-    "node_modules/simple-get": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-3.1.1.tgz",
-      "integrity": "sha512-CQ5LTKGfCpvE1K0n2us+kuMPbk/q0EKl82s4aheV9oXjFEz6W/Y7oQFVJuU6QG77hRT4Ghb5RURteF5vnWjupA==",
-      "dependencies": {
-        "decompress-response": "^4.2.0",
-        "once": "^1.3.1",
-        "simple-concat": "^1.0.0"
-      }
     },
     "node_modules/simple-swizzle": {
       "version": "0.2.2",
@@ -6323,21 +6395,75 @@
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
-    "@mapbox/node-pre-gyp": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/@mapbox/node-pre-gyp/-/node-pre-gyp-1.0.10.tgz",
-      "integrity": "sha512-4ySo4CjzStuprMwk35H5pPbkymjv1SF3jGLj6rAHp/xT/RF7TL7bd9CTm1xDY49K2qF7jmR/g7k+SkLETP6opA==",
+    "@napi-rs/canvas": {
+      "version": "0.1.30",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas/-/canvas-0.1.30.tgz",
+      "integrity": "sha512-XRR6PumJW9GdODD+HFW7ZKmpq7FE6PIKWn7QTcsJUdGNb54fTS1Z47oPFZ3pbvs07Xs8ZnkR03Q/9T3LfkGRgg==",
       "requires": {
-        "detect-libc": "^2.0.0",
-        "https-proxy-agent": "^5.0.0",
-        "make-dir": "^3.1.0",
-        "node-fetch": "^2.6.7",
-        "nopt": "^5.0.0",
-        "npmlog": "^5.0.1",
-        "rimraf": "^3.0.2",
-        "semver": "^7.3.5",
-        "tar": "^6.1.11"
+        "@napi-rs/canvas-android-arm64": "0.1.30",
+        "@napi-rs/canvas-darwin-arm64": "0.1.30",
+        "@napi-rs/canvas-darwin-x64": "0.1.30",
+        "@napi-rs/canvas-linux-arm-gnueabihf": "0.1.30",
+        "@napi-rs/canvas-linux-arm64-gnu": "0.1.30",
+        "@napi-rs/canvas-linux-arm64-musl": "0.1.30",
+        "@napi-rs/canvas-linux-x64-gnu": "0.1.30",
+        "@napi-rs/canvas-linux-x64-musl": "0.1.30",
+        "@napi-rs/canvas-win32-x64-msvc": "0.1.30"
       }
+    },
+    "@napi-rs/canvas-android-arm64": {
+      "version": "0.1.30",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-android-arm64/-/canvas-android-arm64-0.1.30.tgz",
+      "integrity": "sha512-RaJvfg5x8QV+3WVqxwi1dt05mqiDuQF/w4wj8b6SHbxbVLfzZ5T0M9PFBTvjNU88GxiiVYUihxJeCCDs1sXP0g==",
+      "optional": true
+    },
+    "@napi-rs/canvas-darwin-arm64": {
+      "version": "0.1.30",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-arm64/-/canvas-darwin-arm64-0.1.30.tgz",
+      "integrity": "sha512-ZWW7+YYGFREzeV1uoGv0uUx+0OhGd5jQ6zFdaGYFESUjmLlfZ/LS0CG/IlbWDiWbnRPu2HQl0/TOQHurleJjLw==",
+      "optional": true
+    },
+    "@napi-rs/canvas-darwin-x64": {
+      "version": "0.1.30",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-x64/-/canvas-darwin-x64-0.1.30.tgz",
+      "integrity": "sha512-DThro7Y3QFV/9bl/EORWXzBMXeIZU1jo80oI8Ha2Xsoy3Eq+wHhnlMyvNYcLjalxIFU/JJrzu6/qxjPaVzcw5A==",
+      "optional": true
+    },
+    "@napi-rs/canvas-linux-arm-gnueabihf": {
+      "version": "0.1.30",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm-gnueabihf/-/canvas-linux-arm-gnueabihf-0.1.30.tgz",
+      "integrity": "sha512-bMz85lH3y2JL7Xf8szu/EayyEffN2FSAUtxOm6U3/MLc7jW2Pt8TRhAQQxnv0zNh8ub7qBDky+LspMBPLTDRzA==",
+      "optional": true
+    },
+    "@napi-rs/canvas-linux-arm64-gnu": {
+      "version": "0.1.30",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-gnu/-/canvas-linux-arm64-gnu-0.1.30.tgz",
+      "integrity": "sha512-KHUVFOaG7wE4/GGTLk434GH7DIhPa7hhfMyzLqU1QFRXzjo0KIyO9gecHEF9snXaqvD4c/8YubEtFbWZVMSKUw==",
+      "optional": true
+    },
+    "@napi-rs/canvas-linux-arm64-musl": {
+      "version": "0.1.30",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-musl/-/canvas-linux-arm64-musl-0.1.30.tgz",
+      "integrity": "sha512-9ckRCQbt/ZVNbHvApKhvaRM+mahMl4xryV0vUEKgFHo8Fm4j56dPZRWeKojmk1vSGC9ahY73K1MEb0OaIxOv0Q==",
+      "optional": true
+    },
+    "@napi-rs/canvas-linux-x64-gnu": {
+      "version": "0.1.30",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-gnu/-/canvas-linux-x64-gnu-0.1.30.tgz",
+      "integrity": "sha512-NSyhCClsTBs06ViivDU0lSGVTDBBtm3pSTQKZseAnBEEF0vuO4De5SJl4JYng9eSDQ6KqA4TkOZFUMxokP6ZVg==",
+      "optional": true
+    },
+    "@napi-rs/canvas-linux-x64-musl": {
+      "version": "0.1.30",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-musl/-/canvas-linux-x64-musl-0.1.30.tgz",
+      "integrity": "sha512-hT3sPij6nHKiH10avrd8MNwLYEBzwiVyzA0nxPosGJ+ErWk1tgE4UeM3w1+BWYK3S/wgY/4WlhxDgsd9crUGRA==",
+      "optional": true
+    },
+    "@napi-rs/canvas-win32-x64-msvc": {
+      "version": "0.1.30",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-x64-msvc/-/canvas-win32-x64-msvc-0.1.30.tgz",
+      "integrity": "sha512-6MwkIMd53jNqO+KAvv2A7TtMY1MYE51VCdF7sZ61sypgjB/dOYmYqDgAU/RTHS5agyc0CZUeXoaZT43Lkgk67A==",
+      "optional": true
     },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -6993,16 +7119,6 @@
         "quick-lru": "^4.0.1"
       }
     },
-    "canvas": {
-      "version": "2.10.1",
-      "resolved": "https://registry.npmjs.org/canvas/-/canvas-2.10.1.tgz",
-      "integrity": "sha512-29pIjn9uwTUsIgJUNd7GXxKk8sg4iyJwLm1wIilNIqX1mVzXSc2nUij9exW1LqNpis1d2ebMYfMqTWcokZ4pdA==",
-      "requires": {
-        "@mapbox/node-pre-gyp": "^1.0.0",
-        "nan": "^2.15.0",
-        "simple-get": "^3.0.3"
-      }
-    },
     "chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -7598,14 +7714,6 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
       "integrity": "sha512-hjf+xovcEn31w/EUYdTXQh/8smFL/dzYjohQGEIgjyNavaJfBY2p5F527Bo1VPATxv0VYTUC2bOcXvqFwk78Og=="
-    },
-    "decompress-response": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-4.2.1.tgz",
-      "integrity": "sha512-jOSne2qbyE+/r8G1VU+G/82LBs2Fs4LAsTiLSHOCOMZQl2OKZ6i8i4IyHemTe+/yIXOtTcRQMzPcgyhoFlqPkw==",
-      "requires": {
-        "mimic-response": "^2.0.0"
-      }
     },
     "deep-is": {
       "version": "0.1.4",
@@ -9069,11 +9177,6 @@
         "mime-db": "1.52.0"
       }
     },
-    "mimic-response": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-2.1.0.tgz",
-      "integrity": "sha512-wXqjST+SLt7R009ySCglWBCFpjUygmCIfD790/kVbiGmUgfYGuB14PiTd5DwVxSV4NcYHjzMkoj5LjQZwTQLEA=="
-    },
     "min-indent": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
@@ -9822,21 +9925,6 @@
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="
-    },
-    "simple-concat": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
-      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q=="
-    },
-    "simple-get": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-3.1.1.tgz",
-      "integrity": "sha512-CQ5LTKGfCpvE1K0n2us+kuMPbk/q0EKl82s4aheV9oXjFEz6W/Y7oQFVJuU6QG77hRT4Ghb5RURteF5vnWjupA==",
-      "requires": {
-        "decompress-response": "^4.2.0",
-        "once": "^1.3.1",
-        "simple-concat": "^1.0.0"
-      }
     },
     "simple-swizzle": {
       "version": "0.2.2",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "zlib-sync": "^0.1.7"
   },
   "devDependencies": {
-    "@tsconfig/node16": "^1.0.3",
+    "@tsconfig/node18": "^1.0.1",
     "@types/color": "^3.0.3",
     "@types/concat-stream": "^2.0.0",
     "@types/cron": "^1.7.3",
@@ -70,7 +70,7 @@
     "typescript": "^4.8.4"
   },
   "engines": {
-    "node": ">= 16.14.0"
+    "node": ">= 18.10.0"
   },
   "scripts": {
     "build": "rimraf dist/ && tsc",

--- a/package.json
+++ b/package.json
@@ -20,9 +20,9 @@
   "dependencies": {
     "@discordjs/opus": "^0.8.0",
     "@discordjs/voice": "^0.13.0",
+    "@napi-rs/canvas": "^0.1.30",
     "@top-gg/sdk": "^3.1.3",
     "bufferutil": "^4.0.6",
-    "canvas": "^2.10.1",
     "chalk": "^4.1.2",
     "color": "^4.2.3",
     "comlink": "^4.3.1",
@@ -70,7 +70,8 @@
     "typescript": "^4.8.4"
   },
   "engines": {
-    "node": ">= 18.10.0"
+    "node": ">= 18.10.0",
+    "npm": ">= 8.19.0"
   },
   "scripts": {
     "build": "rimraf dist/ && tsc",
@@ -87,6 +88,5 @@
     "release:patch": "standard-version --release-as patch",
     "release:push": "git push --follow-tags origin main && git checkout stable && git merge main && git push --follow-tags origin stable && git checkout main",
     "health": "curl -f http://localhost:6969/ || exit 1"
-  },
-  "bin": "./dist/cli.js"
+  }
 }

--- a/src/modules/canvas/visualize-audio.ts
+++ b/src/modules/canvas/visualize-audio.ts
@@ -2,7 +2,7 @@
  * Waveform algorithm built with guidance from https://css-tricks.com/making-an-audio-waveform-visualizer-with-vanilla-javascript/
  */
 
-import Canvas from "canvas";
+import { createCanvas, SKRSContext2D } from "@napi-rs/canvas";
 import ffmpeg from "fluent-ffmpeg";
 import concatStream from "concat-stream";
 
@@ -73,7 +73,7 @@ function normalizeData(filtered_data: Float32Array): Float32Array {
  * @param {number} x  the x coordinate of the beginning of the line segment
  * @param {number} height the desired height of the line segment
  */
-function drawLineSegment(ctx: Canvas.CanvasRenderingContext2D, x: number, height: number) {
+function drawLineSegment(ctx: SKRSContext2D, x: number, height: number) {
     ctx.beginPath();
     ctx.moveTo(x, -height);
     ctx.lineTo(x, height);
@@ -87,8 +87,8 @@ function clamp(val: number, min: number, max: number): number {
 /**
  * Draws the audio file into a canvas element.
  */
-function drawToBuffer(normalized_data: Float32Array): Buffer {
-    const canvas = Canvas.createCanvas(WIDTH, HEIGHT);
+async function drawToBuffer(normalized_data: Float32Array): Promise<Buffer> {
+    const canvas = createCanvas(WIDTH, HEIGHT);
     const ctx = canvas.getContext("2d");
 
     ctx.translate(0, HEIGHT / 2); // set Y = 0 to be in the middle of the canvas
@@ -110,9 +110,7 @@ function drawToBuffer(normalized_data: Float32Array): Buffer {
         drawLineSegment(ctx, x, height);
     }
 
-    // can't call toBuffer() with callback, because it will break
-    // the process in Node 16
-    return canvas.toBuffer("image/png", { compressionLevel: 9 });
+    return canvas.encode("png");
 }
 
 export async function visualizeAudio(ogg_audio_path: string): Promise<Buffer> {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,5 @@
 {
-    "extends": "@tsconfig/node16/tsconfig.json",
+    "extends": "@tsconfig/node18/tsconfig.json",
     "compilerOptions": {
         /* Basic Options */
         "allowJs": true /* Allow javascript files to be compiled. */,


### PR DESCRIPTION
Update Node to version 18.10.0 for three years of LTS support yaaaay.

[node-canvas ](https://github.com/Automattic/node-canvas) got replaced with [@napi-rs/canvas](https://github.com/Brooooooklyn/canvas) to support Node 18. It's also significatly faster AND runs on NAPI with 0 dependencies.